### PR TITLE
Fix relation classifier response parsing

### DIFF
--- a/src/services/relation-classifier.test.ts
+++ b/src/services/relation-classifier.test.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { AppConfig } from "../config.js";
+import { MemoryType } from "../types/index.js";
+import type { Memory } from "../types/index.js";
+import { RelationClassifierService } from "./relation-classifier.js";
+
+type TextResponse = {
+  content: Array<{ type: "text"; text: string }>;
+};
+
+type RelationClassifierInternals = {
+  anthropic: {
+    messages: {
+      create: () => Promise<TextResponse>;
+    };
+  };
+  extractJson: (raw: string) => unknown;
+  classify: (
+    newMemory: Memory,
+    candidates: Memory[]
+  ) => Promise<{
+    relations: Array<{
+      existingMemoryId: string;
+      relationType: "UPDATE" | "EXTEND" | "DERIVE" | "NONE";
+      confidence: number;
+      derivedFact?: string;
+    }>;
+  }>;
+  batchClassify: (
+    entries: Array<{
+      newMemory: Memory;
+      candidates: Array<{ memory: Memory; score: number }>;
+    }>
+  ) => Promise<{
+    classifications: Array<{
+      newMemoryId: string;
+      relations: Array<{
+        existingMemoryId: string;
+        relationType: "UPDATE" | "EXTEND" | "DERIVE" | "NONE";
+        confidence: number;
+        derivedFact?: string;
+      }>;
+    }>;
+  }>;
+};
+
+function makeMemory(id: string, content: string): Memory {
+  return {
+    id,
+    content,
+    memoryType: MemoryType.Fact,
+    containerTag: "test-relations",
+    isLatest: true,
+    confidence: 0.9,
+    embedding: [0.1, 0.2],
+    createdAt: "2026-07-13T00:00:00.000Z",
+    sourceDocId: "test-document"
+  };
+}
+
+function makeService(responseText?: string): RelationClassifierInternals {
+  const service = new RelationClassifierService(
+    {
+      ANTHROPIC_API_KEY: "test-key",
+      ANTHROPIC_MODEL: "test-model"
+    } as AppConfig,
+    {} as never,
+    {} as never,
+    {} as never
+  ) as unknown as RelationClassifierInternals;
+
+  if (responseText !== undefined) {
+    service.anthropic = {
+      messages: {
+        create: async () => ({
+          content: [{ type: "text", text: responseText }]
+        })
+      }
+    };
+  }
+
+  return service;
+}
+
+describe("RelationClassifierService response normalization", () => {
+  it("parses plain, fenced, explanatory and trailing-comma JSON", () => {
+    const service = makeService();
+    const expected = { relations: [] };
+
+    assert.deepEqual(service.extractJson('{"relations":[]}'), expected);
+    assert.deepEqual(
+      service.extractJson('```json\n{"relations":[]}\n```'),
+      expected
+    );
+    assert.deepEqual(
+      service.extractJson('```\n{"relations":[]}\n```'),
+      expected
+    );
+    assert.deepEqual(
+      service.extractJson('Resultado:\n```JSON\n{"relations":[],}\n```\nFin.'),
+      expected
+    );
+    assert.deepEqual(
+      service.extractJson(
+        '{"relations":[{"derivedFact":"Conserva,}",}],}'
+      ),
+      { relations: [{ derivedFact: "Conserva,}" }] }
+    );
+  });
+
+  it("accepts and removes derivedFact null for a non-DERIVE relation", async () => {
+    const response = JSON.stringify({
+      relations: [
+        {
+          existingMemoryId: "existing",
+          relationType: "EXTEND",
+          confidence: 0.91,
+          derivedFact: null
+        }
+      ]
+    });
+    const service = makeService(`\`\`\`\n${response}\n\`\`\``);
+
+    const result = await service.classify(
+      makeMemory("new", "New detail"),
+      [makeMemory("existing", "Existing fact")]
+    );
+
+    assert.deepEqual(result.relations, [
+      {
+        existingMemoryId: "existing",
+        relationType: "EXTEND",
+        confidence: 0.91,
+        derivedFact: undefined
+      }
+    ]);
+  });
+
+  it("does not treat literal code fences inside valid JSON as an outer wrapper", () => {
+    const service = makeService();
+    const expected = {
+      relations: [
+        {
+          existingMemoryId: "existing",
+          relationType: "DERIVE",
+          confidence: 0.95,
+          derivedFact: "Preserve this example: ```json\n{\"active\":true}\n```"
+        }
+      ]
+    };
+
+    assert.deepEqual(service.extractJson(JSON.stringify(expected)), expected);
+  });
+
+  it("normalizes derivedFact null in batch responses", async () => {
+    const response = JSON.stringify({
+      classifications: [
+        {
+          newMemoryId: "new",
+          relations: [
+            {
+              existingMemoryId: "existing",
+              relationType: "NONE",
+              confidence: 0.8,
+              derivedFact: null
+            }
+          ]
+        }
+      ]
+    });
+    const service = makeService(`Response:\n\`\`\`json\n${response}\n\`\`\``);
+    const newMemory = makeMemory("new", "New fact");
+    const existing = makeMemory("existing", "Existing fact");
+
+    const result = await service.batchClassify([
+      {
+        newMemory,
+        candidates: [{ memory: existing, score: 0.9 }]
+      }
+    ]);
+
+    assert.deepEqual(result.classifications[0]?.relations[0], {
+      existingMemoryId: "existing",
+      relationType: "NONE",
+      confidence: 0.8,
+      derivedFact: undefined
+    });
+  });
+
+  it("rejects DERIVE without a non-empty derived fact", async () => {
+    const response = JSON.stringify({
+      relations: [
+        {
+          existingMemoryId: "existing",
+          relationType: "DERIVE",
+          confidence: 0.95,
+          derivedFact: null
+        }
+      ]
+    });
+    const service = makeService(response);
+
+    await assert.rejects(
+      service.classify(
+        makeMemory("new", "New fact"),
+        [makeMemory("existing", "Existing fact")]
+      ),
+      /derivedFact/
+    );
+  });
+
+  it("rejects batch DERIVE without a non-empty derived fact", async () => {
+    const response = JSON.stringify({
+      classifications: [
+        {
+          newMemoryId: "new",
+          relations: [
+            {
+              existingMemoryId: "existing",
+              relationType: "DERIVE",
+              confidence: 0.95,
+              derivedFact: null
+            }
+          ]
+        }
+      ]
+    });
+    const service = makeService(response);
+    const newMemory = makeMemory("new", "New fact");
+    const existing = makeMemory("existing", "Existing fact");
+
+    await assert.rejects(
+      service.batchClassify([
+        {
+          newMemory,
+          candidates: [{ memory: existing, score: 0.9 }]
+        }
+      ]),
+      /derivedFact/
+    );
+  });
+});

--- a/src/services/relation-classifier.ts
+++ b/src/services/relation-classifier.ts
@@ -20,12 +20,27 @@ Para DERIVE: la combinación de hechos permite inferir algo nuevo. Ejemplo: 'es 
 
 Responde con: {relations: [{existingMemoryId, relationType, confidence, derivedFact?}]}`;
 
-const relationSchema = z.object({
-  existingMemoryId: z.string().min(1),
-  relationType: z.enum(["UPDATE", "EXTEND", "DERIVE", "NONE"]),
-  confidence: z.number().min(0).max(1),
-  derivedFact: z.string().optional()
-});
+const optionalDerivedFactSchema = z.preprocess(
+  (value) => (value === null ? undefined : value),
+  z.string().trim().min(1).optional()
+);
+
+const relationSchema = z
+  .object({
+    existingMemoryId: z.string().min(1),
+    relationType: z.enum(["UPDATE", "EXTEND", "DERIVE", "NONE"]),
+    confidence: z.number().min(0).max(1),
+    derivedFact: optionalDerivedFactSchema
+  })
+  .superRefine((relation, context) => {
+    if (relation.relationType === "DERIVE" && !relation.derivedFact) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["derivedFact"],
+        message: "DERIVE relations require a non-empty derivedFact"
+      });
+    }
+  });
 
 const responseSchema = z.object({
   relations: z.array(relationSchema)
@@ -46,12 +61,7 @@ Para DERIVE: la combinación de hechos permite inferir algo nuevo. Ejemplo: 'es 
 Responde con: {classifications: [{newMemoryId, relations: [{existingMemoryId, relationType, confidence, derivedFact?}]}]}
 Incluye una entrada por cada newMemoryId recibido, incluso si todas sus relaciones son NONE.`;
 
-const batchRelationSchema = z.object({
-  existingMemoryId: z.string().min(1),
-  relationType: z.enum(["UPDATE", "EXTEND", "DERIVE", "NONE"]),
-  confidence: z.number().min(0).max(1),
-  derivedFact: z.string().optional()
-});
+const batchRelationSchema = relationSchema;
 
 const batchResponseSchema = z.object({
   classifications: z.array(
@@ -356,9 +366,115 @@ export class RelationClassifierService {
   }
 
   private extractJson(raw: string): unknown {
-    const fenced = raw.match(/```json\s*([\s\S]*?)\s*```/i);
-    const payload = fenced?.[1] ?? raw;
-    return JSON.parse(payload.trim());
+    const payload = raw.trim();
+
+    try {
+      return this.parseJsonPayload(payload);
+    } catch (directError) {
+      const objectPayload = this.extractFirstJsonObject(payload);
+      if (!objectPayload) {
+        throw directError;
+      }
+      return this.parseJsonPayload(objectPayload);
+    }
+  }
+
+  private parseJsonPayload(payload: string): unknown {
+    try {
+      return JSON.parse(payload);
+    } catch (error) {
+      const withoutTrailingCommas = this.removeTrailingCommas(payload);
+      if (withoutTrailingCommas === payload) {
+        throw error;
+      }
+      return JSON.parse(withoutTrailingCommas);
+    }
+  }
+
+  private extractFirstJsonObject(raw: string): string | null {
+    let objectStart = -1;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+
+    for (let index = 0; index < raw.length; index += 1) {
+      const character = raw.charAt(index);
+
+      if (objectStart < 0) {
+        if (character === "{") {
+          objectStart = index;
+          depth = 1;
+        }
+        continue;
+      }
+
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === "\\") {
+          escaped = true;
+        } else if (character === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (character === '"') {
+        inString = true;
+      } else if (character === "{") {
+        depth += 1;
+      } else if (character === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          return raw.slice(objectStart, index + 1);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private removeTrailingCommas(raw: string): string {
+    let normalized = "";
+    let inString = false;
+    let escaped = false;
+
+    for (let index = 0; index < raw.length; index += 1) {
+      const character = raw.charAt(index);
+
+      if (inString) {
+        normalized += character;
+        if (escaped) {
+          escaped = false;
+        } else if (character === "\\") {
+          escaped = true;
+        } else if (character === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (character === '"') {
+        inString = true;
+        normalized += character;
+        continue;
+      }
+
+      if (character === ",") {
+        let nextIndex = index + 1;
+        while (nextIndex < raw.length && /\s/.test(raw.charAt(nextIndex))) {
+          nextIndex += 1;
+        }
+        const nextCharacter = raw.charAt(nextIndex);
+        if (nextCharacter === "}" || nextCharacter === "]") {
+          continue;
+        }
+      }
+
+      normalized += character;
+    }
+
+    return normalized;
   }
 
   private resolveExistingMemoryId(value: string, candidates: Memory[]): string {


### PR DESCRIPTION
## Summary
- parse valid Anthropic JSON before applying recovery
- recover fenced/prose JSON with balanced object extraction
- normalize `derivedFact: null` for non-DERIVE relations while enforcing DERIVE content
- add focused single and batch regression tests

## Verification
- `npm run build`
- 27/27 valid Node tests
- focused `openai-codex/gpt-5.6-terra` audit: APPROVED

## Known pre-existing test issue
`src/tests/ingestion.test.ts` is legacy Jest-style code with wrong imports and undeclared dependencies; it is unrelated to this diff and not part of the valid Node test set.