### PR TITLE
fix: accept blank non-DERIVE facts

### DIFF
--- a/src/services/relation-classifier.test.ts
+++ b/src/services/relation-classifier.test.ts
@@ -138,6 +138,34 @@ describe("RelationClassifierService response normalization", () => {
     ]);
   });
 
+  it("accepts and removes a blank derivedFact for a non-DERIVE relation", async () => {
+    const response = JSON.stringify({
+      relations: [
+        {
+          existingMemoryId: "existing",
+          relationType: "UPDATE",
+          confidence: 0.87,
+          derivedFact: "   "
+        }
+      ]
+    });
+    const service = makeService(response);
+
+    const result = await service.classify(
+      makeMemory("new", "Replacement fact"),
+      [makeMemory("existing", "Existing fact")]
+    );
+
+    assert.deepEqual(result.relations, [
+      {
+        existingMemoryId: "existing",
+        relationType: "UPDATE",
+        confidence: 0.87,
+        derivedFact: undefined
+      }
+    ]);
+  });
+
   it("does not treat literal code fences inside valid JSON as an outer wrapper", () => {
     const service = makeService();
     const expected = {

--- a/src/services/relation-classifier.ts
+++ b/src/services/relation-classifier.ts
@@ -21,7 +21,10 @@ Para DERIVE: la combinación de hechos permite inferir algo nuevo. Ejemplo: 'es 
 Responde con: {relations: [{existingMemoryId, relationType, confidence, derivedFact?}]}`;
 
 const optionalDerivedFactSchema = z.preprocess(
-  (value) => (value === null ? undefined : value),
+  (value) =>
+    value === null || (typeof value === "string" && value.trim() === "")
+      ? undefined
+      : value,
   z.string().trim().min(1).optional()
 );
 


### PR DESCRIPTION
## Summary
- normalize blank `derivedFact` placeholders to `undefined`
- preserve the existing requirement that DERIVE relations include non-empty content
- add a focused regression for non-DERIVE whitespace placeholders

## Checks
- `node --import tsx --test src/services/relation-classifier.test.ts` (7 passed)
- `npm run build`
- `git diff --check`

Follow-up to Codex review on #30.
