### PR TITLE
fix: make knowledge repair retries idempotent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.18.0",
         "neo4j-driver": "^5.28.1",
         "openai": "^5.15.0",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -933,7 +933,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1166,7 +1165,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1846,9 +1844,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -1893,7 +1891,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@modelcontextprotocol/sdk": "^1.18.0",
     "neo4j-driver": "^5.28.1",
     "openai": "^5.15.0",
-    "uuid": "^11.1.0",
+    "uuid": "^11.1.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/admin/repair-knowledge.ts
+++ b/src/admin/repair-knowledge.ts
@@ -1,0 +1,88 @@
+import { loadConfig } from "../config.js";
+import { Neo4jClient } from "../db/neo4j-client.js";
+import { EmbeddingService } from "../services/embedding.js";
+import { ForgettingService } from "../services/forgetting.js";
+import { IngestionPipeline } from "../services/ingestion/pipeline.js";
+import { MemoryExtractorService } from "../services/ingestion/memory-extractor.js";
+import { RelationClassifierService } from "../services/relation-classifier.js";
+
+function requireUuid(value: string | undefined, label: string): string {
+  if (!value || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)) {
+    throw new Error(`${label} must be a UUID`);
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  const [command, rawId, repairId] = process.argv.slice(2);
+  const id = requireUuid(rawId, command === "reprocess-document" ? "documentId" : "memoryId");
+  const config = loadConfig();
+  const neo4jClient = new Neo4jClient(config);
+  const embeddingService = new EmbeddingService(config);
+  const forgettingService = new ForgettingService(neo4jClient);
+  const relationClassifierService = new RelationClassifierService(
+    config,
+    neo4jClient,
+    embeddingService,
+    forgettingService
+  );
+
+  try {
+    if (command === "reclassify-memory") {
+      const memory = await neo4jClient.getMemory(id);
+      if (!memory) {
+        throw new Error(`Memory not found: ${id}`);
+      }
+      const result = await relationClassifierService.classifyAndApply(memory);
+      console.log(JSON.stringify({
+        command,
+        memoryId: id,
+        candidateCount: result.candidateCount,
+        appliedCount: result.applied.length
+      }));
+      return;
+    }
+
+    if (command === "reprocess-document") {
+      if (!repairId || !/^[a-z0-9._:-]{3,80}$/i.test(repairId)) {
+        throw new Error("repairId must be a 3-80 character operational identifier");
+      }
+      const prepared = await neo4jClient.prepareDocumentForReprocessing(id, repairId);
+      const memoryExtractorService = new MemoryExtractorService(config);
+      const pipeline = new IngestionPipeline(
+        neo4jClient,
+        embeddingService,
+        relationClassifierService,
+        memoryExtractorService
+      );
+      try {
+        const result = await pipeline.processDocument(id);
+        await neo4jClient.completeDocumentReprocessing(id, repairId);
+        console.log(JSON.stringify({
+          command,
+          documentId: id,
+          status: result.document.status,
+          deletedChunkCount: prepared.deletedChunkCount,
+          deletedMemoryCount: prepared.deletedMemoryCount,
+          chunkCount: result.chunkCount,
+          memoryCount: result.memoryCount
+        }));
+      } catch (error) {
+        await neo4jClient.releaseDocumentReprocessing(id, repairId);
+        throw error;
+      }
+      return;
+    }
+
+    throw new Error(
+      "Usage: repair-knowledge reclassify-memory <uuid> | reprocess-document <uuid> <repairId>"
+    );
+  } finally {
+    await neo4jClient.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(`[repair-knowledge] ${(error as Error).message}`);
+  process.exit(1);
+});

--- a/src/db/neo4j-client.ts
+++ b/src/db/neo4j-client.ts
@@ -1,5 +1,5 @@
 import neo4j, { Driver, Integer } from "neo4j-driver";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4, v5 as uuidv5 } from "uuid";
 import type { AppConfig } from "../config.js";
 import { DocumentStatus, MemoryType, RelationType } from "../types/enums.js";
 import type {
@@ -59,6 +59,8 @@ type ChunkCreateInput = {
   metadata?: Metadata | string;
   sourceDocId: string;
 };
+
+const DERIVED_MEMORY_ID_NAMESPACE = "6f95d7ad-e62f-4c43-b74a-b722f8394d97";
 
 /** Neo4j data access layer for Documents, Memories, and relations. */
 export class Neo4jClient {
@@ -244,6 +246,150 @@ export class Neo4jClient {
   }
 
   /**
+   * Removes generated artifacts before safely reprocessing an existing document.
+   * Refuses to continue when extracted memories already exist.
+   * @param documentId Document identifier.
+   */
+  public async prepareDocumentForReprocessing(
+    documentId: string,
+    repairId: string
+  ): Promise<{
+    document: Document;
+    deletedChunkCount: number;
+    deletedMemoryCount: number;
+  }> {
+    const session = this.driver.session();
+    try {
+      return await session.executeWrite(async (tx) => {
+        const now = new Date();
+        const check = await tx.run(
+          `
+          MATCH (d:Document {id: $documentId})
+          SET d.repairLockVersion = coalesce(d.repairLockVersion, 0) + 1
+          RETURN d.repairRunId AS existingRepairId,
+                 d.repairLeaseUntil AS repairLeaseUntil
+          `,
+          { documentId }
+        );
+        if (check.records.length === 0) {
+          throw new Error(`Document not found: ${documentId}`);
+        }
+
+        const existingRepairId = check.records[0]?.get("existingRepairId");
+        const leaseValue = check.records[0]?.get("repairLeaseUntil");
+        if (existingRepairId && String(existingRepairId) !== repairId) {
+          throw new Error(
+            `Refusing to reprocess document ${documentId}: another repair run owns it`
+          );
+        }
+        if (
+          existingRepairId &&
+          leaseValue &&
+          new Date(String(leaseValue)).getTime() > now.getTime()
+        ) {
+          throw new Error(`Refusing to reprocess document ${documentId}: repair lease is active`);
+        }
+
+        const memoryCountResult = await tx.run(
+          `
+          MATCH (d:Document {id: $documentId})
+          OPTIONAL MATCH (m:Memory)-[:EXTRACTED_FROM]->(d)
+          RETURN count(m) AS memoryCount
+          `,
+          { documentId }
+        );
+        const memoryCount = Number(memoryCountResult.records[0]?.get("memoryCount") ?? 0);
+        if (!existingRepairId && memoryCount > 0) {
+          throw new Error(
+            `Refusing to start repair for document ${documentId}: ${memoryCount} extracted memories already exist`
+          );
+        }
+
+        const memoryCleanup = await tx.run(
+          `
+          MATCH (m:Memory)-[:EXTRACTED_FROM]->(:Document {id: $documentId})
+          DETACH DELETE m
+          `,
+          { documentId }
+        );
+        const chunkCleanup = await tx.run(
+          `
+          MATCH (c:Chunk)-[:EXTRACTED_FROM]->(:Document {id: $documentId})
+          DETACH DELETE c
+          `,
+          { documentId }
+        );
+
+        const leaseUntil = new Date(now.getTime() + 30 * 60 * 1000).toISOString();
+        const claim = await tx.run(
+          `
+          MATCH (d:Document {id: $documentId})
+          SET d.repairRunId = $repairId,
+              d.repairLeaseUntil = datetime($leaseUntil),
+              d.status = $extractingStatus,
+              d.updatedAt = datetime($updatedAt)
+          RETURN d
+          `,
+          {
+            documentId,
+            repairId,
+            leaseUntil,
+            extractingStatus: DocumentStatus.Extracting,
+            updatedAt: new Date().toISOString()
+          }
+        );
+
+        return {
+          document: this.mapDocument(claim.records[0]?.get("d")),
+          deletedChunkCount: chunkCleanup.summary.counters.updates().nodesDeleted,
+          deletedMemoryCount: memoryCleanup.summary.counters.updates().nodesDeleted
+        };
+      });
+    } finally {
+      await session.close();
+    }
+  }
+
+  /** Clears a successful document repair claim. */
+  public async completeDocumentReprocessing(documentId: string, repairId: string): Promise<void> {
+    const session = this.driver.session();
+    try {
+      const result = await session.run(
+        `
+        MATCH (d:Document {id: $documentId, repairRunId: $repairId})
+        REMOVE d.repairRunId, d.repairLeaseUntil, d.repairLockVersion
+        SET d.updatedAt = datetime($updatedAt)
+        RETURN d
+        `,
+        { documentId, repairId, updatedAt: new Date().toISOString() }
+      );
+      if (result.records.length === 0) {
+        throw new Error(`Repair claim not found for document ${documentId}`);
+      }
+    } finally {
+      await session.close();
+    }
+  }
+
+  /** Releases a failed repair lease while retaining its retry ownership. */
+  public async releaseDocumentReprocessing(documentId: string, repairId: string): Promise<void> {
+    const session = this.driver.session();
+    try {
+      await session.run(
+        `
+        MATCH (d:Document {id: $documentId, repairRunId: $repairId})
+        SET d.repairLeaseUntil = datetime(),
+            d.updatedAt = datetime()
+        RETURN d
+        `,
+        { documentId, repairId }
+      );
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
    * Deletes a document and returns true if it existed.
    * @param documentId Document identifier.
    */
@@ -384,34 +530,68 @@ export class Neo4jClient {
     embedding: number[];
   }): Promise<Memory> {
     const session = this.driver.session();
-    const id = uuidv4();
+    const sourceMemoryIds = [...new Set(params.sourceMemoryIds)].sort();
+    const id = uuidv5(
+      JSON.stringify({
+        content: params.content,
+        containerTag: params.containerTag,
+        sourceDocId: params.sourceDocId,
+        sourceMemoryIds
+      }),
+      DERIVED_MEMORY_ID_NAMESPACE
+    );
     const now = new Date().toISOString();
 
     try {
-      const result = await session.executeWrite((tx) =>
-        tx.run(
+      const result = await session.executeWrite(async (tx) => {
+        const existingResult = await tx.run(
           `
-          MATCH (d:Document {id: $sourceDocId})
-          CREATE (derived:Memory {
-            id: $id,
-            content: $content,
+          MATCH (derived:Memory {
             memoryType: $memoryType,
             containerTag: $containerTag,
-            isLatest: true,
-            confidence: 0.6,
-            originalConfidence: NULL,
-            embedding: $embedding,
-            validFrom: NULL,
-            validTo: NULL,
-            forgottenAt: NULL,
-            createdAt: datetime($createdAt),
-            sourceDocId: $sourceDocId
-          })
-          CREATE (derived)-[:EXTRACTED_FROM]->(d)
-          WITH derived
-          UNWIND $sourceMemoryIds AS sourceId
-          MATCH (source:Memory {id: sourceId})
-          CREATE (derived)-[:DERIVES]->(source)
+            sourceDocId: $sourceDocId,
+            content: $content
+          })-[:DERIVES]->(source:Memory)
+          WITH derived, collect(DISTINCT source.id) AS existingSourceIds
+          WHERE size(existingSourceIds) = size($sourceMemoryIds)
+            AND all(sourceId IN $sourceMemoryIds WHERE sourceId IN existingSourceIds)
+          RETURN derived
+          LIMIT 1
+          `,
+          {
+            content: params.content,
+            memoryType: MemoryType.Derived,
+            containerTag: params.containerTag,
+            sourceDocId: params.sourceDocId,
+            sourceMemoryIds
+          }
+        );
+        if (existingResult.records.length > 0) {
+          return existingResult;
+        }
+
+        return tx.run(
+          `
+          MATCH (d:Document {id: $sourceDocId})
+          MATCH (source:Memory)
+          WHERE source.id IN $sourceMemoryIds
+          WITH d, collect(DISTINCT source) AS sources
+          WHERE size(sources) = size($sourceMemoryIds)
+          MERGE (derived:Memory {id: $id})
+          ON CREATE SET derived.content = $content,
+                        derived.memoryType = $memoryType,
+                        derived.containerTag = $containerTag,
+                        derived.isLatest = true,
+                        derived.confidence = 0.6,
+                        derived.originalConfidence = NULL,
+                        derived.embedding = $embedding,
+                        derived.validFrom = NULL,
+                        derived.validTo = NULL,
+                        derived.forgottenAt = NULL,
+                        derived.createdAt = datetime($createdAt),
+                        derived.sourceDocId = $sourceDocId
+          MERGE (derived)-[:EXTRACTED_FROM]->(d)
+          FOREACH (source IN sources | MERGE (derived)-[:DERIVES]->(source))
           RETURN derived
           LIMIT 1
           `,
@@ -421,12 +601,12 @@ export class Neo4jClient {
             memoryType: MemoryType.Derived,
             containerTag: params.containerTag,
             sourceDocId: params.sourceDocId,
-            sourceMemoryIds: params.sourceMemoryIds,
+            sourceMemoryIds,
             createdAt: now,
             embedding: params.embedding
           }
-        )
-      );
+        );
+      });
 
       if (result.records.length === 0) {
         throw new Error("Failed to create derived memory");
@@ -1134,7 +1314,7 @@ export class Neo4jClient {
     fromMemoryId: string,
     toMemoryId: string,
     relationType: RelationType
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (
       relationType !== RelationType.Updates &&
       relationType !== RelationType.Extends &&
@@ -1145,7 +1325,7 @@ export class Neo4jClient {
 
     const session = this.driver.session();
     try {
-      await session.run(
+      const result = await session.run(
         `
         MATCH (from:Memory {id: $fromMemoryId})
         MATCH (to:Memory {id: $toMemoryId})
@@ -1154,6 +1334,7 @@ export class Neo4jClient {
         `,
         { fromMemoryId, toMemoryId }
       );
+      return result.summary.counters.updates().relationshipsCreated > 0;
     } finally {
       await session.close();
     }

--- a/src/services/ingestion/memory-extractor.test.ts
+++ b/src/services/ingestion/memory-extractor.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { AppConfig } from "../../config.js";
+import { MemoryExtractorService } from "./memory-extractor.js";
+
+type ExtractorInternals = {
+  anthropic: {
+    messages: {
+      create: () => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+    };
+  };
+  extractFromChunk: MemoryExtractorService["extractFromChunk"];
+};
+
+function makeService(response: string | Error): ExtractorInternals {
+  const service = new MemoryExtractorService({
+    ANTHROPIC_API_KEY: "test-key",
+    ANTHROPIC_MODEL: "test-model"
+  } as AppConfig) as unknown as ExtractorInternals;
+  service.anthropic = {
+    messages: {
+      create: async () => {
+        if (response instanceof Error) {
+          throw response;
+        }
+        return { content: [{ type: "text", text: response }] };
+      }
+    }
+  };
+  return service;
+}
+
+describe("MemoryExtractorService failure handling", () => {
+  it("accepts a valid response with no durable memories", async () => {
+    const service = makeService('{"memories":[]}');
+    assert.deepEqual(await service.extractFromChunk("No durable facts"), []);
+  });
+
+  it("propagates provider failures instead of returning an empty success", async () => {
+    const error = Object.assign(new Error("provider failed"), { status: 429 });
+    const service = makeService(error);
+    await assert.rejects(
+      service.extractFromChunk("Some content"),
+      /Anthropic extraction request failed \(HTTP 429\)/
+    );
+  });
+
+  it("rejects malformed JSON instead of returning an empty success", async () => {
+    const service = makeService("not json");
+    await assert.rejects(
+      service.extractFromChunk("Some content"),
+      /response was not valid JSON/
+    );
+  });
+
+  it("recovers valid memories from a partially invalid response", async () => {
+    const service = makeService(JSON.stringify({
+      memories: [
+        { content: "Durable fact", memoryType: "fact", confidence: 0.9 },
+        { content: "", memoryType: "fact", confidence: 0.9 }
+      ]
+    }));
+    const memories = await service.extractFromChunk("Some content");
+    assert.equal(memories.length, 1);
+    assert.equal(memories[0]?.content, "Durable fact");
+  });
+});

--- a/src/services/ingestion/memory-extractor.ts
+++ b/src/services/ingestion/memory-extractor.ts
@@ -69,50 +69,54 @@ export class MemoryExtractorService {
       2
     );
 
+    let response;
     try {
-      const response = await this.anthropic.messages.create({
+      response = await this.anthropic.messages.create({
         model: this.model,
         max_tokens: 4096,
         system: EXTRACTION_SYSTEM_PROMPT,
         messages: [{ role: "user", content: userPrompt }]
       });
+    } catch (apiError) {
+      const status = (apiError as { status?: unknown }).status;
+      const suffix = typeof status === "number" ? ` (HTTP ${status})` : "";
+      throw new Error(`Anthropic extraction request failed${suffix}`);
+    }
 
-      const combinedText = response.content
-        .filter((block) => block.type === "text")
-        .map((block) => block.text)
-        .join("\n");
+    const combinedText = response.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
 
-      const jsonData = this.extractJson(combinedText);
-      if (!jsonData) {
-        console.warn("[extractor] Failed to parse JSON from Anthropic response, returning empty memories");
-        console.warn("[extractor] Raw response (first 500 chars):", combinedText.substring(0, 500));
-        return [];
-      }
+    const jsonData = this.extractJson(combinedText);
+    if (!jsonData) {
+      throw new Error("Anthropic extraction response was not valid JSON");
+    }
 
-      try {
-        const parsed = extractionResponseSchema.parse(jsonData);
-        return parsed.memories;
-      } catch (zodError) {
-        console.warn("[extractor] Zod validation failed, attempting lenient parse:", (zodError as Error).message);
-        // Try lenient parse: accept any structure with a memories array
-        if (jsonData && typeof jsonData === "object" && "memories" in (jsonData as Record<string, unknown>) && Array.isArray((jsonData as Record<string, unknown>).memories)) {
-          const memories = (jsonData as { memories: unknown[] }).memories;
-          const validMemories: ExtractedMemory[] = [];
-          for (const m of memories) {
-            try {
-              validMemories.push(extractedMemorySchema.parse(m));
-            } catch {
-              // Skip invalid individual memories
-            }
+    try {
+      const parsed = extractionResponseSchema.parse(jsonData);
+      return parsed.memories;
+    } catch {
+      if (
+        jsonData &&
+        typeof jsonData === "object" &&
+        "memories" in (jsonData as Record<string, unknown>) &&
+        Array.isArray((jsonData as Record<string, unknown>).memories)
+      ) {
+        const memories = (jsonData as { memories: unknown[] }).memories;
+        const validMemories: ExtractedMemory[] = [];
+        for (const memory of memories) {
+          const parsedMemory = extractedMemorySchema.safeParse(memory);
+          if (parsedMemory.success) {
+            validMemories.push(parsedMemory.data);
           }
+        }
+        if (validMemories.length > 0) {
           console.log(`[extractor] Lenient parse recovered ${validMemories.length}/${memories.length} memories`);
           return validMemories;
         }
-        return [];
       }
-    } catch (apiError) {
-      console.error("[extractor] Anthropic API error:", (apiError as Error).message);
-      return [];
+      throw new Error("Anthropic extraction response failed schema validation");
     }
   }
 

--- a/src/services/relation-classifier.test.ts
+++ b/src/services/relation-classifier.test.ts
@@ -269,4 +269,53 @@ describe("RelationClassifierService response normalization", () => {
       /derivedFact/
     );
   });
+
+  it("does not reinforce a preference when an EXTEND relation already existed", async () => {
+    const existing = {
+      ...makeMemory("existing", "Existing preference"),
+      memoryType: MemoryType.Preference
+    };
+    const newMemory = makeMemory("new", "Additional preference detail");
+    let reinforcementCount = 0;
+    const neo4jClient = {
+      semanticSearchMemories: async () => [{ memory: existing, score: 0.9 }],
+      createMemoryRelation: async () => false
+    };
+    const forgettingService = {
+      reinforcePreference: async () => {
+        reinforcementCount += 1;
+        return true;
+      }
+    };
+    const service = new RelationClassifierService(
+      {
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_MODEL: "test-model"
+      } as AppConfig,
+      neo4jClient as never,
+      {} as never,
+      forgettingService as never
+    ) as unknown as RelationClassifierInternals & {
+      classifyAndApply: RelationClassifierService["classifyAndApply"];
+    };
+    service.anthropic = {
+      messages: {
+        create: async () => ({
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              relations: [{
+                existingMemoryId: "existing",
+                relationType: "EXTEND",
+                confidence: 0.9
+              }]
+            })
+          }]
+        })
+      }
+    };
+
+    await service.classifyAndApply(newMemory);
+    assert.equal(reinforcementCount, 0);
+  });
 });

--- a/src/services/relation-classifier.ts
+++ b/src/services/relation-classifier.ts
@@ -146,12 +146,12 @@ export class RelationClassifierService {
         const targetMemory = filteredCandidates
           .map((candidate) => candidate.memory)
           .find((candidate) => candidate.id === relation.existingMemoryId);
-        await this.neo4jClient.createMemoryRelation(
+        const relationCreated = await this.neo4jClient.createMemoryRelation(
           newMemory.id,
           relation.existingMemoryId,
           RelationType.Extends
         );
-        if (targetMemory?.memoryType === MemoryType.Preference) {
+        if (relationCreated && targetMemory?.memoryType === MemoryType.Preference) {
           await this.forgettingService.reinforcePreference(targetMemory.id);
         }
         applied.push({ relationType: "EXTEND", existingMemoryId: relation.existingMemoryId });
@@ -243,12 +243,12 @@ export class RelationClassifierService {
           const targetMemory = cands
             .map((c) => c.memory)
             .find((c) => c.id === relation.existingMemoryId);
-          await this.neo4jClient.createMemoryRelation(
+          const relationCreated = await this.neo4jClient.createMemoryRelation(
             mem.id,
             relation.existingMemoryId,
             RelationType.Extends
           );
-          if (targetMemory?.memoryType === MemoryType.Preference) {
+          if (relationCreated && targetMemory?.memoryType === MemoryType.Preference) {
             await this.forgettingService.reinforcePreference(targetMemory.id);
           }
           continue;

--- a/tests/test_mcp_tool_registration.py
+++ b/tests/test_mcp_tool_registration.py
@@ -6,6 +6,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 NEO4J_CLIENT_PATH = REPO_ROOT / "src" / "db" / "neo4j-client.ts"
 SERVER_PATH = REPO_ROOT / "src" / "server.ts"
+REPAIR_CLI_PATH = REPO_ROOT / "src" / "admin" / "repair-knowledge.ts"
 
 
 def _read(path: Path) -> str:
@@ -105,3 +106,13 @@ def test_existing_core_tools_remain_registered() -> None:
         'name: "setup_schema"',
     ]:
         assert tool_name in server_source
+
+
+def test_repair_operations_remain_admin_only() -> None:
+    server_source = _read(SERVER_PATH)
+    repair_source = _read(REPAIR_CLI_PATH)
+
+    assert 'name: "reprocess_document"' not in server_source
+    assert 'name: "reclassify_memory"' not in server_source
+    assert "prepareDocumentForReprocessing" in repair_source
+    assert "classifyAndApply" in repair_source


### PR DESCRIPTION
## Summary
- adds admin-only, lease-protected repair commands
- makes derived-memory and preference side effects idempotent
- propagates extractor/provider failures instead of false empty success
- updates uuid to the patched release

## Checks
- TypeScript build
- 18/18 focused Node tests
- 5/5 Python registration/security tests
- isolated Neo4j retry/concurrency/exact-source smoke
- focused gpt-5.6-terra audit: APPROVED

## Security
Repair commands remain container-admin only and are not exposed as MCP tools.