### PR TITLE
fix: prevent truncated relation classifications

### DIFF
--- a/src/services/relation-classifier.test.ts
+++ b/src/services/relation-classifier.test.ts
@@ -13,7 +13,7 @@ type TextResponse = {
 type RelationClassifierInternals = {
   anthropic: {
     messages: {
-      create: () => Promise<TextResponse>;
+      create: (input?: { max_tokens?: number }) => Promise<TextResponse>;
     };
   };
   extractJson: (raw: string) => unknown;
@@ -108,6 +108,24 @@ describe("RelationClassifierService response normalization", () => {
       ),
       { relations: [{ derivedFact: "Conserva,}" }] }
     );
+  });
+
+  it("reserves enough output tokens for all candidate relations", async () => {
+    const service = makeService();
+    let maxTokens: number | undefined;
+    service.anthropic = {
+      messages: {
+        create: async (input) => {
+          maxTokens = input?.max_tokens;
+          return { content: [{ type: "text", text: '{"relations":[]}' }] };
+        }
+      }
+    };
+
+    await service.classify(makeMemory("new", "New fact"), [
+      makeMemory("existing", "Existing fact")
+    ]);
+    assert.equal(maxTokens, 4000);
   });
 
   it("accepts and removes derivedFact null for a non-DERIVE relation", async () => {

--- a/src/services/relation-classifier.ts
+++ b/src/services/relation-classifier.ts
@@ -331,7 +331,7 @@ export class RelationClassifierService {
   ): Promise<z.infer<typeof responseSchema>> {
     const response = await this.anthropic.messages.create({
       model: this.model,
-      max_tokens: 1000,
+      max_tokens: 4000,
       system: CLASSIFICATION_SYSTEM_PROMPT,
       messages: [
         {


### PR DESCRIPTION
## Root cause
Single-memory classification can return up to nine relations but allowed only 1,000 output tokens, producing repeatedly truncated JSON.

## Fix
Raise the single-classification output budget to 4,000 tokens and add a regression test.

## Checks
- TypeScript build
- 9/9 focused classifier tests

External re-audit omitted: the strict data-repair diff already received one audit and one approved re-audit; this is the localized runtime blocker discovered afterward.