### PR TITLE
fix: scope relation repair to historical state

### DIFF
--- a/src/admin/repair-knowledge.ts
+++ b/src/admin/repair-knowledge.ts
@@ -33,7 +33,9 @@ async function main(): Promise<void> {
       if (!memory) {
         throw new Error(`Memory not found: ${id}`);
       }
-      const result = await relationClassifierService.classifyAndApply(memory);
+      const result = await relationClassifierService.classifyAndApply(memory, {
+        asOf: memory.createdAt
+      });
       console.log(JSON.stringify({
         command,
         memoryId: id,

--- a/src/db/neo4j-client.ts
+++ b/src/db/neo4j-client.ts
@@ -745,6 +745,7 @@ export class Neo4jClient {
     minScore?: number;
     limit?: number;
     isLatestOnly?: boolean;
+    asOf?: string;
   }): Promise<MemorySearchHit[]> {
     const session = this.driver.session();
     const limit = params.limit ?? 10;
@@ -758,9 +759,24 @@ export class Neo4jClient {
         CALL db.index.vector.queryNodes('memory_embeddings', $vectorLimit, $embedding)
         YIELD node, score
         WHERE ($containerTag IS NULL OR node.containerTag = $containerTag)
-          AND ($isLatestOnly = false OR node.isLatest = true)
-          AND node.forgottenAt IS NULL
-          AND (node.validTo IS NULL OR node.validTo >= datetime())
+          AND ($asOf IS NULL OR node.createdAt <= datetime($asOf))
+          AND ($asOf IS NULL OR node.validFrom IS NULL OR node.validFrom <= datetime($asOf))
+          AND (
+            ($asOf IS NULL AND node.forgottenAt IS NULL)
+            OR ($asOf IS NOT NULL AND (node.forgottenAt IS NULL OR node.forgottenAt > datetime($asOf)))
+          )
+          AND (
+            ($asOf IS NULL AND (node.validTo IS NULL OR node.validTo >= datetime()))
+            OR ($asOf IS NOT NULL AND (node.validTo IS NULL OR node.validTo >= datetime($asOf)))
+          )
+          AND (
+            $isLatestOnly = false
+            OR ($asOf IS NULL AND node.isLatest = true)
+            OR ($asOf IS NOT NULL AND NOT EXISTS {
+              MATCH (superseding:Memory)-[:UPDATES]->(node)
+              WHERE superseding.createdAt <= datetime($asOf)
+            })
+          )
           AND score >= $minScore
         RETURN node, score
         ORDER BY score DESC
@@ -772,7 +788,8 @@ export class Neo4jClient {
           embedding: params.embedding,
           containerTag: params.containerTag ?? null,
           minScore: params.minScore ?? 0,
-          isLatestOnly: params.isLatestOnly ?? false
+          isLatestOnly: params.isLatestOnly ?? false,
+          asOf: params.asOf ?? null
         }
       );
 
@@ -1305,15 +1322,17 @@ export class Neo4jClient {
   }
 
   /**
-   * Creates a relation between two memories.
+   * Creates a relation between two memories and applies its target-side effect atomically.
    * @param fromMemoryId Source memory id.
    * @param toMemoryId Target memory id.
    * @param relationType Neo4j relation type.
+   * @param options Optional target mutation guarded by relation creation.
    */
   public async createMemoryRelation(
     fromMemoryId: string,
     toMemoryId: string,
-    relationType: RelationType
+    relationType: RelationType,
+    options: { markTargetNotLatest?: boolean; reinforceTargetPreference?: boolean } = {}
   ): Promise<boolean> {
     if (
       relationType !== RelationType.Updates &&
@@ -1329,12 +1348,30 @@ export class Neo4jClient {
         `
         MATCH (from:Memory {id: $fromMemoryId})
         MATCH (to:Memory {id: $toMemoryId})
+        OPTIONAL MATCH (from)-[existing:${relationType}]->(to)
+        WITH from, to, count(existing) AS existingCount
         MERGE (from)-[r:${relationType}]->(to)
-        RETURN r
+        FOREACH (_ IN CASE WHEN $markTargetNotLatest THEN [1] ELSE [] END |
+          SET to.isLatest = false
+        )
+        FOREACH (_ IN CASE WHEN $reinforceTargetPreference AND existingCount = 0 THEN [1] ELSE [] END |
+          SET to.originalConfidence = coalesce(to.originalConfidence, to.confidence),
+              to.confidence = CASE
+                WHEN coalesce(to.confidence, 0) + 0.15 > 1 THEN 1
+                ELSE coalesce(to.confidence, 0) + 0.15
+              END,
+              to.lastReinforcedAt = datetime()
+        )
+        RETURN existingCount = 0 AS created
         `,
-        { fromMemoryId, toMemoryId }
+        {
+          fromMemoryId,
+          toMemoryId,
+          markTargetNotLatest: options.markTargetNotLatest ?? false,
+          reinforceTargetPreference: options.reinforceTargetPreference ?? false
+        }
       );
-      return result.summary.counters.updates().relationshipsCreated > 0;
+      return Boolean(result.records[0]?.get("created"));
     } finally {
       await session.close();
     }

--- a/src/services/relation-classifier.test.ts
+++ b/src/services/relation-classifier.test.ts
@@ -288,16 +288,25 @@ describe("RelationClassifierService response normalization", () => {
     );
   });
 
-  it("does not reinforce a preference when an EXTEND relation already existed", async () => {
+  it("delegates preference reinforcement to the atomic relation write", async () => {
     const existing = {
       ...makeMemory("existing", "Existing preference"),
       memoryType: MemoryType.Preference
     };
     const newMemory = makeMemory("new", "Additional preference detail");
     let reinforcementCount = 0;
+    let relationOptions: { reinforceTargetPreference?: boolean } | undefined;
     const neo4jClient = {
       semanticSearchMemories: async () => [{ memory: existing, score: 0.9 }],
-      createMemoryRelation: async () => false
+      createMemoryRelation: async (
+        _from: string,
+        _to: string,
+        _type: string,
+        options?: { reinforceTargetPreference?: boolean }
+      ) => {
+        relationOptions = options;
+        return false;
+      }
     };
     const forgettingService = {
       reinforcePreference: async () => {
@@ -335,5 +344,30 @@ describe("RelationClassifierService response normalization", () => {
 
     await service.classifyAndApply(newMemory);
     assert.equal(reinforcementCount, 0);
+    assert.equal(relationOptions?.reinforceTargetPreference, true);
+  });
+
+  it("forwards the historical cutoff to candidate search", async () => {
+    const newMemory = makeMemory("new", "Historical fact");
+    let searchOptions: { asOf?: string } | undefined;
+    const neo4jClient = {
+      semanticSearchMemories: async (options: { asOf?: string }) => {
+        searchOptions = options;
+        return [];
+      }
+    };
+    const service = new RelationClassifierService(
+      {
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_MODEL: "test-model"
+      } as AppConfig,
+      neo4jClient as never,
+      {} as never,
+      {} as never
+    );
+
+    const result = await service.classifyAndApply(newMemory, { asOf: newMemory.createdAt });
+    assert.equal(result.candidateCount, 0);
+    assert.equal(searchOptions?.asOf, newMemory.createdAt);
   });
 });

--- a/src/services/relation-classifier.ts
+++ b/src/services/relation-classifier.ts
@@ -107,7 +107,10 @@ export class RelationClassifierService {
    * Classifies relations for a new memory and applies resulting graph updates.
    * @param newMemory Newly created memory.
    */
-  public async classifyAndApply(newMemory: Memory): Promise<{
+  public async classifyAndApply(
+    newMemory: Memory,
+    options: { asOf?: string } = {}
+  ): Promise<{
     candidateCount: number;
     applied: Array<{ relationType: string; existingMemoryId?: string; derivedMemoryId?: string }>;
   }> {
@@ -116,7 +119,8 @@ export class RelationClassifierService {
       containerTag: newMemory.containerTag,
       minScore: 0.75,
       limit: 10,
-      isLatestOnly: true
+      isLatestOnly: true,
+      asOf: options.asOf
     });
 
     const filteredCandidates = candidates
@@ -135,9 +139,9 @@ export class RelationClassifierService {
         await this.neo4jClient.createMemoryRelation(
           newMemory.id,
           relation.existingMemoryId,
-          RelationType.Updates
+          RelationType.Updates,
+          { markTargetNotLatest: true }
         );
-        await this.neo4jClient.markMemoryNotLatest(relation.existingMemoryId);
         applied.push({ relationType: "UPDATE", existingMemoryId: relation.existingMemoryId });
         continue;
       }
@@ -146,14 +150,12 @@ export class RelationClassifierService {
         const targetMemory = filteredCandidates
           .map((candidate) => candidate.memory)
           .find((candidate) => candidate.id === relation.existingMemoryId);
-        const relationCreated = await this.neo4jClient.createMemoryRelation(
+        await this.neo4jClient.createMemoryRelation(
           newMemory.id,
           relation.existingMemoryId,
-          RelationType.Extends
+          RelationType.Extends,
+          { reinforceTargetPreference: targetMemory?.memoryType === MemoryType.Preference }
         );
-        if (relationCreated && targetMemory?.memoryType === MemoryType.Preference) {
-          await this.forgettingService.reinforcePreference(targetMemory.id);
-        }
         applied.push({ relationType: "EXTEND", existingMemoryId: relation.existingMemoryId });
         continue;
       }
@@ -233,9 +235,9 @@ export class RelationClassifierService {
           await this.neo4jClient.createMemoryRelation(
             mem.id,
             relation.existingMemoryId,
-            RelationType.Updates
+            RelationType.Updates,
+            { markTargetNotLatest: true }
           );
-          await this.neo4jClient.markMemoryNotLatest(relation.existingMemoryId);
           continue;
         }
 
@@ -243,14 +245,12 @@ export class RelationClassifierService {
           const targetMemory = cands
             .map((c) => c.memory)
             .find((c) => c.id === relation.existingMemoryId);
-          const relationCreated = await this.neo4jClient.createMemoryRelation(
+          await this.neo4jClient.createMemoryRelation(
             mem.id,
             relation.existingMemoryId,
-            RelationType.Extends
+            RelationType.Extends,
+            { reinforceTargetPreference: targetMemory?.memoryType === MemoryType.Preference }
           );
-          if (relationCreated && targetMemory?.memoryType === MemoryType.Preference) {
-            await this.forgettingService.reinforcePreference(targetMemory.id);
-          }
           continue;
         }
 


### PR DESCRIPTION
## Root cause
Historical memories were being compared against the current graph. This could create future-facing relations and invert UPDATE chronology. Relation side effects also ran in separate writes.

## Fix
- reconstruct candidate eligibility as of the source memory timestamp
- make UPDATE latest-state and preference reinforcement atomic with relation creation
- use the historical cutoff only for the admin repair command

## Checks
- TypeScript build
- 14/14 focused Node tests
- 5/5 Python MCP registration tests
- isolated Neo4j smoke: future excluded, UPDATE atomic, preference reinforced once

## Audit
The delivery already consumed the allowed focused audit and approved re-audit. This runtime-discovered follow-up was self-reviewed and tested locally; no additional audit loop was started.