### PR TITLE
fix: safely correct classifier UUID typos

### DIFF
--- a/src/services/relation-classifier.test.ts
+++ b/src/services/relation-classifier.test.ts
@@ -370,4 +370,39 @@ describe("RelationClassifierService response normalization", () => {
     assert.equal(result.candidateCount, 0);
     assert.equal(searchOptions?.asOf, newMemory.createdAt);
   });
+
+  it("corrects a unique one-character UUID transcription error", async () => {
+    const candidateId = "44dd897a-99a1-45df-8065-975afc1eb2d8";
+    const response = JSON.stringify({
+      relations: [{
+        existingMemoryId: "44dd897a-9a1-45df-8065-975afc1eb2d8",
+        relationType: "EXTEND",
+        confidence: 0.9
+      }]
+    });
+    const service = makeService(response);
+    const result = await service.classify(
+      makeMemory("new", "New fact"),
+      [makeMemory(candidateId, "Existing fact")]
+    );
+    assert.equal(result.relations[0].existingMemoryId, candidateId);
+  });
+
+  it("rejects ambiguous one-character UUID corrections", async () => {
+    const response = JSON.stringify({
+      relations: [{
+        existingMemoryId: "44dd897a-9a1-45df-8065-975afc1eb2d8",
+        relationType: "EXTEND",
+        confidence: 0.9
+      }]
+    });
+    const service = makeService(response);
+    await assert.rejects(
+      service.classify(makeMemory("new", "New fact"), [
+        makeMemory("44dd897a-99a1-45df-8065-975afc1eb2d8", "First"),
+        makeMemory("44dd897a-a9a1-45df-8065-975afc1eb2d8", "Second")
+      ]),
+      /unknown existingMemoryId/
+    );
+  });
 });

--- a/src/services/relation-classifier.ts
+++ b/src/services/relation-classifier.ts
@@ -490,6 +490,47 @@ export class RelationClassifierService {
       return byContent.id;
     }
 
+    const nearUuidMatches = candidates.filter((candidate) =>
+      this.isSingleEditAway(value, candidate.id)
+    );
+    if (nearUuidMatches.length === 1) {
+      return nearUuidMatches[0]!.id;
+    }
+
     throw new Error(`Classifier returned unknown existingMemoryId: ${value}`);
+  }
+
+  private isSingleEditAway(left: string, right: string): boolean {
+    if (Math.abs(left.length - right.length) > 1) {
+      return false;
+    }
+
+    let leftIndex = 0;
+    let rightIndex = 0;
+    let edits = 0;
+    while (leftIndex < left.length && rightIndex < right.length) {
+      if (left.charAt(leftIndex) === right.charAt(rightIndex)) {
+        leftIndex += 1;
+        rightIndex += 1;
+        continue;
+      }
+      edits += 1;
+      if (edits > 1) {
+        return false;
+      }
+      if (left.length > right.length) {
+        leftIndex += 1;
+      } else if (right.length > left.length) {
+        rightIndex += 1;
+      } else {
+        leftIndex += 1;
+        rightIndex += 1;
+      }
+    }
+
+    if (leftIndex < left.length || rightIndex < right.length) {
+      edits += 1;
+    }
+    return edits === 1;
   }
 }


### PR DESCRIPTION
## Root cause
Anthropic omitted one character from a candidate UUID, causing two deterministic repair attempts to fail.

## Fix
Resolve a one-character UUID transcription only when exactly one candidate matches at edit distance 1. Ambiguous or larger changes remain hard failures.

## Checks
- TypeScript build
- 12/12 focused classifier tests, including unique correction and ambiguous rejection
- git diff check