### PR TITLE
fix: preserve EXTENDS evidence across repair retries

### DIFF
--- a/src/db/neo4j-client.test.ts
+++ b/src/db/neo4j-client.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { AppConfig } from "../config.js";
+import { Neo4jClient } from "./neo4j-client.js";
+import { RelationType } from "../types/enums.js";
+
+const config = {
+  NEO4J_URI: "bolt://127.0.0.1:7687",
+  NEO4J_USER: "test",
+  NEO4J_PASSWORD: "test",
+  OPENAI_API_KEY: "test",
+  ANTHROPIC_API_KEY: "test",
+  ANTHROPIC_MODEL: "test",
+  OPENAI_EMBEDDING_MODEL: "test",
+  COHERE_RERANK_MODEL: "test"
+} as AppConfig;
+
+type FakeSession = {
+  run?: (query: string, params: Record<string, unknown>) => Promise<unknown>;
+  executeWrite?: (work: (transaction: { run: FakeSession["run"] }) => Promise<unknown>) => Promise<unknown>;
+  close: () => Promise<void>;
+};
+
+function clientWithSession(session: FakeSession): Neo4jClient {
+  const client = new Neo4jClient(config);
+  (client as unknown as { driver: { session: () => FakeSession } }).driver = {
+    session: () => session
+  };
+  return client;
+}
+
+function counters(nodesDeleted = 0, relationshipsCreated = 0) {
+  return {
+    updates: () => ({ nodesDeleted, relationshipsCreated })
+  };
+}
+
+describe("Neo4jClient repair relation idempotency", () => {
+  it("preserves EXTENDS evidence before deleting generated memories", async () => {
+    const queries: string[] = [];
+    const transaction = {
+      run: async (query: string) => {
+        queries.push(query);
+        if (query.includes("repairLockVersion")) {
+          return {
+            records: [{ get: (key: string) => key === "existingRepairId" ? "repair-1" : null }]
+          };
+        }
+        if (query.includes("DETACH DELETE m")) {
+          return { records: [], summary: { counters: counters(1) } };
+        }
+        if (query.includes("DETACH DELETE c")) {
+          return { records: [], summary: { counters: counters(2) } };
+        }
+        if (query.includes("SET d.repairRunId")) {
+          return {
+            records: [{
+              get: () => ({
+                properties: {
+                  id: "document-1",
+                  title: "Document",
+                  contentType: "text",
+                  rawContent: "content",
+                  containerTag: "test",
+                  metadata: {},
+                  status: "extracting",
+                  createdAt: "2026-07-13T00:00:00.000Z",
+                  updatedAt: "2026-07-13T00:00:00.000Z"
+                }
+              })
+            }]
+          };
+        }
+        return { records: [], summary: { counters: counters() } };
+      }
+    };
+    const client = clientWithSession({
+      executeWrite: async (work) => work(transaction),
+      close: async () => undefined
+    });
+
+    const result = await client.prepareDocumentForReprocessing("document-1", "repair-1");
+
+    const preserveIndex = queries.findIndex((query) => query.includes("REPAIR_EXTENDS"));
+    const deleteIndex = queries.findIndex((query) => query.includes("DETACH DELETE m"));
+    assert.ok(preserveIndex >= 0);
+    assert.ok(deleteIndex > preserveIndex);
+    assert.equal(result.deletedMemoryCount, 1);
+    assert.equal(result.deletedChunkCount, 2);
+  });
+
+  it("gates atomic preference reinforcement when an EXTENDS repair marker exists", async () => {
+    const queries: string[] = [];
+    const parameters: Array<Record<string, unknown>> = [];
+    const markedClient = clientWithSession({
+      run: async (query, params) => {
+        queries.push(query);
+        parameters.push(params);
+        return {
+          records: [{ get: (key: string) => key === "created" }],
+          summary: { counters: counters(0, 1) }
+        };
+      },
+      close: async () => undefined
+    });
+
+    assert.equal(
+      await markedClient.createMemoryRelation(
+        "new-memory",
+        "preference",
+        RelationType.Extends,
+        { reinforceTargetPreference: true }
+      ),
+      true
+    );
+    assert.match(queries[0] ?? "", /source\.id = from\.sourceDocId/);
+    assert.match(queries[0] ?? "", /NOT preservedFromRepair/);
+    assert.equal(parameters[0]?.checkRepairMarker, true);
+    assert.equal(parameters[0]?.reinforceTargetPreference, true);
+
+    const updateParameters: Array<Record<string, unknown>> = [];
+    const updateClient = clientWithSession({
+      run: async (_query, params) => {
+        updateParameters.push(params);
+        return {
+          records: [{ get: (key: string) => key === "created" }],
+          summary: { counters: counters(0, 1) }
+        };
+      },
+      close: async () => undefined
+    });
+    assert.equal(
+      await updateClient.createMemoryRelation(
+        "other-memory",
+        "existing-memory",
+        RelationType.Updates,
+        { markTargetNotLatest: true }
+      ),
+      true
+    );
+    assert.equal(updateParameters[0]?.checkRepairMarker, false);
+  });
+
+  it("retains repair markers on release and removes them only on completion", async () => {
+    const queries: string[] = [];
+    const client = clientWithSession({
+      run: async (query) => {
+        queries.push(query);
+        return { records: [{}], summary: { counters: counters() } };
+      },
+      close: async () => undefined
+    });
+
+    await client.releaseDocumentReprocessing("document-1", "repair-1");
+    await client.completeDocumentReprocessing("document-1", "repair-1");
+
+    assert.doesNotMatch(queries[0] ?? "", /DELETE preserved/);
+    assert.match(queries[1] ?? "", /DELETE preserved/);
+    assert.match(queries[1] ?? "", /repairRunId: \$repairId/);
+  });
+});

--- a/src/db/neo4j-client.ts
+++ b/src/db/neo4j-client.ts
@@ -305,6 +305,15 @@ export class Neo4jClient {
           );
         }
 
+        await tx.run(
+          `
+          MATCH (d:Document {id: $documentId})
+          MATCH (m:Memory)-[:EXTRACTED_FROM]->(d)
+          MATCH (m)-[:EXTENDS]->(target:Memory)
+          MERGE (d)-[:REPAIR_EXTENDS]->(target)
+          `,
+          { documentId }
+        );
         const memoryCleanup = await tx.run(
           `
           MATCH (m:Memory)-[:EXTRACTED_FROM]->(:Document {id: $documentId})
@@ -357,9 +366,11 @@ export class Neo4jClient {
       const result = await session.run(
         `
         MATCH (d:Document {id: $documentId, repairRunId: $repairId})
+        OPTIONAL MATCH (d)-[preserved:REPAIR_EXTENDS]->(:Memory)
+        DELETE preserved
         REMOVE d.repairRunId, d.repairLeaseUntil, d.repairLockVersion
         SET d.updatedAt = datetime($updatedAt)
-        RETURN d
+        RETURN DISTINCT d
         `,
         { documentId, repairId, updatedAt: new Date().toISOString() }
       );
@@ -1350,11 +1361,14 @@ export class Neo4jClient {
         MATCH (to:Memory {id: $toMemoryId})
         OPTIONAL MATCH (from)-[existing:${relationType}]->(to)
         WITH from, to, count(existing) AS existingCount
+        OPTIONAL MATCH (source:Document)-[preserved:REPAIR_EXTENDS]->(to)
+        WHERE $checkRepairMarker AND source.id = from.sourceDocId
+        WITH from, to, existingCount, count(preserved) > 0 AS preservedFromRepair
         MERGE (from)-[r:${relationType}]->(to)
         FOREACH (_ IN CASE WHEN $markTargetNotLatest THEN [1] ELSE [] END |
           SET to.isLatest = false
         )
-        FOREACH (_ IN CASE WHEN $reinforceTargetPreference AND existingCount = 0 THEN [1] ELSE [] END |
+        FOREACH (_ IN CASE WHEN $reinforceTargetPreference AND existingCount = 0 AND NOT preservedFromRepair THEN [1] ELSE [] END |
           SET to.originalConfidence = coalesce(to.originalConfidence, to.confidence),
               to.confidence = CASE
                 WHEN coalesce(to.confidence, 0) + 0.15 > 1 THEN 1
@@ -1367,6 +1381,7 @@ export class Neo4jClient {
         {
           fromMemoryId,
           toMemoryId,
+          checkRepairMarker: relationType === RelationType.Extends,
           markTargetNotLatest: options.markTargetNotLatest ?? false,
           reinforceTargetPreference: options.reinforceTargetPreference ?? false
         }


### PR DESCRIPTION
## Root cause
A failed document repair deletes partially generated memories and their `EXTENDS` edges. A retry creates fresh memory IDs, so the atomic relation write introduced in #34 could reinforce the same preference again on every failed retry.

## Fix
- preserve document-scoped `EXTENDS` evidence before cleanup inside the existing repair transaction
- create the restored memory relation while suppressing duplicate preference reinforcement when that evidence exists
- retain evidence across failed retries and remove it only after successful completion
- keep unrelated documents independent

## Validation
- Neo4j DAL + relation classifier: 15 passed
- TypeScript build: passed
- real Neo4j 5.24 synthetic smoke: two retries kept confidence at 0.5, successful completion removed markers, unrelated document reinforced to 0.65
- Codex native `gpt-5.6-terra`: APPROVED
- Claude OAuth `claude-fable-5`: APPROVED

This branch was rebased over #34 and #35. No real Neo4j/user data, provider, production service, or deployment was touched. The repository has no GitHub Actions workflows. Existing npm dependency findings are unchanged because package files were not modified.

Follow-up to #32.
