### PR TITLE
fix: harden historical relation repair

### DIFF
--- a/src/db/neo4j-client.test.ts
+++ b/src/db/neo4j-client.test.ts
@@ -37,6 +37,51 @@ function counters(nodesDeleted = 0, relationshipsCreated = 0) {
 }
 
 describe("Neo4jClient repair relation idempotency", () => {
+  it("expands historical vector search past newer filtered candidates", async () => {
+    const vectorLimits: number[] = [];
+    const client = clientWithSession({
+      run: async (query, params = {}) => {
+        if (query.includes("count(node) AS count")) {
+          return { records: [{ get: () => 250 }] };
+        }
+        const vectorLimit = Number(String(params.vectorLimit));
+        vectorLimits.push(vectorLimit);
+        if (vectorLimit < 250) {
+          return { records: [] };
+        }
+        return {
+          records: [{
+            get: (key: string) => key === "score"
+              ? 0.91
+              : {
+                properties: {
+                  id: "historical-memory",
+                  content: "Historical fact",
+                  memoryType: "fact",
+                  containerTag: "test",
+                  isLatest: true,
+                  confidence: 0.9,
+                  embedding: [0.1, 0.2],
+                  createdAt: "2026-01-01T00:00:00.000Z",
+                  sourceDocId: "document-1"
+                }
+              }
+          }]
+        };
+      },
+      close: async () => undefined
+    });
+
+    const result = await client.semanticSearchMemories({
+      embedding: [0.1, 0.2],
+      asOf: "2026-01-02T00:00:00.000Z",
+      limit: 10
+    });
+
+    assert.deepEqual(vectorLimits, [100, 200, 250]);
+    assert.equal(result[0]?.memory.id, "historical-memory");
+  });
+
   it("preserves EXTENDS evidence before deleting generated memories", async () => {
     const queries: string[] = [];
     const transaction = {
@@ -116,6 +161,7 @@ describe("Neo4jClient repair relation idempotency", () => {
     );
     assert.match(queries[0] ?? "", /source\.id = from\.sourceDocId/);
     assert.match(queries[0] ?? "", /NOT preservedFromRepair/);
+    assert.match(queries[0] ?? "", /to\.forgottenAt IS NULL/);
     assert.equal(parameters[0]?.checkRepairMarker, true);
     assert.equal(parameters[0]?.reinforceTargetPreference, true);
 

--- a/src/db/neo4j-client.ts
+++ b/src/db/neo4j-client.ts
@@ -760,12 +760,27 @@ export class Neo4jClient {
   }): Promise<MemorySearchHit[]> {
     const session = this.driver.session();
     const limit = params.limit ?? 10;
-    // When filtering by containerTag, fetch more candidates from the vector index
-    // to compensate for post-filter reduction
-    const vectorLimit = params.containerTag ? limit * 10 : limit;
+    // Historical and container filters run after the vector index ranks nodes.
+    // Start with an overfetch and, for historical repair, expand only as needed
+    // until enough valid hits are found or every indexed memory was considered.
+    let vectorLimit = params.containerTag || params.asOf ? limit * 10 : limit;
+    let maximumVectorLimit = vectorLimit;
 
     try {
-      const result = await session.run(
+      if (params.asOf) {
+        const countResult = await session.run(
+          "MATCH (node:Memory) WHERE node.embedding IS NOT NULL RETURN count(node) AS count"
+        );
+        const countValue = countResult.records[0]?.get("count");
+        const indexedMemoryCount = neo4j.isInt(countValue)
+          ? countValue.toNumber()
+          : Number(countValue ?? 0);
+        if (Number.isFinite(indexedMemoryCount)) {
+          maximumVectorLimit = Math.max(vectorLimit, indexedMemoryCount);
+        }
+      }
+
+      const runSearch = () => session.run(
         `
         CALL db.index.vector.queryNodes('memory_embeddings', $vectorLimit, $embedding)
         YIELD node, score
@@ -803,6 +818,16 @@ export class Neo4jClient {
           asOf: params.asOf ?? null
         }
       );
+
+      let result = await runSearch();
+      while (
+        params.asOf &&
+        result.records.length < limit &&
+        vectorLimit < maximumVectorLimit
+      ) {
+        vectorLimit = Math.min(maximumVectorLimit, vectorLimit * 2);
+        result = await runSearch();
+      }
 
       return result.records.map((record) => ({
         memory: this.mapMemory(record.get("node")),
@@ -1368,7 +1393,7 @@ export class Neo4jClient {
         FOREACH (_ IN CASE WHEN $markTargetNotLatest THEN [1] ELSE [] END |
           SET to.isLatest = false
         )
-        FOREACH (_ IN CASE WHEN $reinforceTargetPreference AND existingCount = 0 AND NOT preservedFromRepair THEN [1] ELSE [] END |
+        FOREACH (_ IN CASE WHEN $reinforceTargetPreference AND existingCount = 0 AND NOT preservedFromRepair AND to.forgottenAt IS NULL THEN [1] ELSE [] END |
           SET to.originalConfidence = coalesce(to.originalConfidence, to.confidence),
               to.confidence = CASE
                 WHEN coalesce(to.confidence, 0) + 0.15 > 1 THEN 1

--- a/src/services/relation-classifier.test.ts
+++ b/src/services/relation-classifier.test.ts
@@ -405,4 +405,38 @@ describe("RelationClassifierService response normalization", () => {
       /unknown existingMemoryId/
     );
   });
+
+  it("does not repair a batch UUID against another entry's candidates", async () => {
+    const response = JSON.stringify({
+      classifications: [{
+        newMemoryId: "new-a",
+        relations: [{
+          existingMemoryId: "44dd897a-9a1-45df-8065-975afc1eb2d8",
+          relationType: "EXTEND",
+          confidence: 0.9
+        }]
+      }]
+    });
+    const service = makeService(response);
+
+    await assert.rejects(
+      service.batchClassify([
+        {
+          newMemory: makeMemory("new-a", "First new fact"),
+          candidates: [{
+            memory: makeMemory("11111111-1111-4111-8111-111111111111", "First candidate"),
+            score: 0.9
+          }]
+        },
+        {
+          newMemory: makeMemory("new-b", "Second new fact"),
+          candidates: [{
+            memory: makeMemory("44dd897a-99a1-45df-8065-975afc1eb2d8", "Second candidate"),
+            score: 0.9
+          }]
+        }
+      ]),
+      /unknown existingMemoryId/
+    );
+  });
 });

--- a/src/services/relation-classifier.ts
+++ b/src/services/relation-classifier.ts
@@ -272,13 +272,12 @@ export class RelationClassifierService {
   private async batchClassify(
     entries: Array<{ newMemory: Memory; candidates: Array<{ memory: Memory; score: number }> }>
   ): Promise<z.infer<typeof batchResponseSchema>> {
-    // Build a flat map of all candidate memories for ID resolution later
-    const allCandidateMemories = new Map<string, Memory>();
-    for (const entry of entries) {
-      for (const c of entry.candidates) {
-        allCandidateMemories.set(c.memory.id, c.memory);
-      }
-    }
+    const candidatesByNewMemoryId = new Map(
+      entries.map((entry) => [
+        entry.newMemory.id,
+        entry.candidates.map((candidate) => candidate.memory)
+      ])
+    );
 
     const response = await this.anthropic.messages.create({
       model: this.model,
@@ -318,7 +317,7 @@ export class RelationClassifierService {
           ...rel,
           existingMemoryId: this.resolveExistingMemoryId(
             rel.existingMemoryId,
-            Array.from(allCandidateMemories.values())
+            candidatesByNewMemoryId.get(cls.newMemoryId) ?? []
           )
         }))
       }))


### PR DESCRIPTION
## Summary
- expand historical vector candidate pools until enough valid as-of hits are found or the index is exhausted
- scope fuzzy UUID repair to each batch entry's own candidates
- prevent forgotten preferences from receiving confidence reinforcement
- add focused regressions for all three review findings

## Root causes
- historical filters were applied after a fixed-size vector query, so newer memories could crowd out valid historical candidates
- batch UUID normalization used a global candidate union across independent entries
- preference reinforcement did not check the target's current forgotten state

## Verification
- `npm exec -- tsx --test src/db/neo4j-client.test.ts src/services/relation-classifier.test.ts` — 17 passed
- `npm run build` — passed
- `git diff --check` — passed

Addresses the actionable P2 reviews on #34 and #35 (reviews 4684386916 and 4684461536).
