### PR TITLE
fix: filter mixed-dimension historical vectors

### DIFF
--- a/src/db/neo4j-client.test.ts
+++ b/src/db/neo4j-client.test.ts
@@ -98,6 +98,11 @@ describe("Neo4jClient repair relation idempotency", () => {
         if (query.includes("vector.similarity.cosine")) {
           exactFallbacks += 1;
           assert.match(query, /MATCH \(node:Memory \{containerTag: \$containerTag\}\)/);
+          assert.match(query, /size\(node\.embedding\) = size\(\$embedding\)/);
+          assert.ok(
+            query.indexOf("size(node.embedding) = size($embedding)")
+              < query.indexOf("vector.similarity.cosine")
+          );
           assert.match(query, /node\.containerTag = \$containerTag/);
           assert.match(query, /node\.createdAt <= datetime\(\$asOf\)/);
           assert.match(query, /node\.validFrom IS NULL/);

--- a/src/db/neo4j-client.ts
+++ b/src/db/neo4j-client.ts
@@ -836,6 +836,7 @@ export class Neo4jClient {
           `
           MATCH (node:Memory {containerTag: $containerTag})
           WHERE node.embedding IS NOT NULL
+            AND size(node.embedding) = size($embedding)
           WITH node, vector.similarity.cosine(node.embedding, $embedding) AS score
           ${memoryFilters}
           RETURN node, score


### PR DESCRIPTION
## Summary
- filter exact historical candidates to the query embedding dimension before cosine similarity
- prevent legacy vectors from aborting historical repair during embedding migrations
- guard predicate placement with a focused regression

## Checks
- Neo4j client tests: 6 passed
- TypeScript build: passed
- Codex gpt-5.6-terra audit: approved
- Claude Fable 5 re-review: approved

Follow-up to #38.