### PR TITLE
Fix Codex bridge Swarm flags

### DIFF
--- a/deploy/deploy_codex_bridge.sh
+++ b/deploy/deploy_codex_bridge.sh
@@ -41,7 +41,6 @@ else
     --user 1000:1000 \
     --read-only \
     --cap-drop ALL \
-    --security-opt no-new-privileges=true \
     --constraint "node.hostname==${node_hostname}" \
     --limit-memory 128M \
     --restart-condition any \

--- a/tests/test_deploy_codex_bridge.py
+++ b/tests/test_deploy_codex_bridge.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_swarm_bridge_uses_supported_hardening_flags() -> None:
+    script = (
+        Path(__file__).resolve().parents[1] / "deploy" / "deploy_codex_bridge.sh"
+    ).read_text(encoding="utf-8")
+    assert "--user 1000:1000" in script
+    assert "--read-only" in script
+    assert "--cap-drop ALL" in script
+    assert "node.hostname==" in script
+    assert "--security-opt" not in script


### PR DESCRIPTION
## Summary
- remove unsupported `--security-opt` from `docker service create`
- retain supported Swarm hardening: UID 1000, read-only rootfs, all capabilities dropped and exact-node placement
- add a regression test for the supported flag set

## Root cause
The target Docker Swarm CLI rejects `--security-opt` for services. The deployment aborted before creating any sidecar task.

## Verification
- `bash -n deploy/deploy_codex_bridge.sh`
- `python3 -m pytest -q tests/test_deploy_codex_bridge.py` — 1/1 PASS
- target VPS confirms `docker service create` does not expose `--security-opt`
