### PR TITLE
Raise Codex request timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,5 @@ OPENAI_CODEX_MODEL=gpt-5.6-luna
 OPENAI_CODEX_BASE_URL=
 # Prefer a Docker secret file. OPENAI_CODEX_RELAY_KEY remains available for local development.
 OPENAI_CODEX_RELAY_KEY_FILE=/run/secrets/supermemento_codex_relay_key
-LLM_REQUEST_TIMEOUT_MS=120000
+LLM_REQUEST_TIMEOUT_MS=180000
 LLM_REASONING_EFFORT=low

--- a/deploy/configure_codex_app.sh
+++ b/deploy/configure_codex_app.sh
@@ -36,7 +36,7 @@ update=(
   --env-add "OPENAI_CODEX_MODEL=${model}"
   --env-add "OPENAI_CODEX_BASE_URL=${base_url}"
   --env-add "OPENAI_CODEX_RELAY_KEY_FILE=/run/secrets/${secret_target}"
-  --env-add "LLM_REQUEST_TIMEOUT_MS=120000"
+  --env-add "LLM_REQUEST_TIMEOUT_MS=180000"
   --env-add "LLM_REASONING_EFFORT=low"
 )
 

--- a/docs/OPENAI_CODEX_OAUTH.md
+++ b/docs/OPENAI_CODEX_OAUTH.md
@@ -45,7 +45,7 @@ LLM_PROVIDER=openai-codex
 OPENAI_CODEX_MODEL=gpt-5.6-luna
 OPENAI_CODEX_BASE_URL=http://codex-oauth-bridge:18646/v1
 OPENAI_CODEX_RELAY_KEY_FILE=/run/secrets/supermemento_codex_relay_key
-LLM_REQUEST_TIMEOUT_MS=120000
+LLM_REQUEST_TIMEOUT_MS=180000
 LLM_REASONING_EFFORT=low
 ```
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -32,6 +32,8 @@ describe("LLM environment configuration", () => {
     delete process.env.LLM_PROVIDER;
     const config = loadConfig();
     assert.equal(config.LLM_PROVIDER, "anthropic");
+    assert.equal(config.ANTHROPIC_MODEL, "claude-haiku-4-5-20251001");
+    assert.equal(config.LLM_REQUEST_TIMEOUT_MS, 180000);
   });
 
   it("accepts a private Codex relay without requiring Anthropic", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,7 +57,7 @@ const envSchema = z
     OPENAI_CODEX_MODEL: z.string().min(1).default("gpt-5.6-luna"),
     OPENAI_CODEX_BASE_URL: z.string().url().optional(),
     OPENAI_CODEX_RELAY_KEY: z.string().min(32).optional(),
-    LLM_REQUEST_TIMEOUT_MS: z.coerce.number().int().min(1000).max(300000).default(120000),
+    LLM_REQUEST_TIMEOUT_MS: z.coerce.number().int().min(1000).max(300000).default(180000),
     LLM_REASONING_EFFORT: z.enum(["low", "medium", "high"]).default("low"),
     COHERE_API_KEY: z.string().min(1).optional(),
     COHERE_RERANK_MODEL: z.string().min(1).default("rerank-v3.5")

--- a/tests/test_configure_codex_app.py
+++ b/tests/test_configure_codex_app.py
@@ -61,6 +61,7 @@ exit 1
     assert "secret create supermemento_codex_relay_key -" in log
     assert r"--secret-add source=supermemento_codex_relay_key\,target=supermemento_codex_relay_key\,mode=0400" in log
     assert "--env-add OPENAI_CODEX_RELAY_KEY_FILE=/run/secrets/supermemento_codex_relay_key" in log
+    assert "--env-add LLM_REQUEST_TIMEOUT_MS=180000" in log
     assert "--env-rm OPENAI_CODEX_RELAY_KEY" in log
     assert "secret_mounted=yes health=200" in result.stdout
     assert "legacy-direct-value" not in result.stdout


### PR DESCRIPTION
## Summary
- raise the default and deployed Codex request timeout from 120s to 180s
- keep app config, example, deployment script and docs aligned
- add regression assertions for both config and Swarm wiring

## Root cause
A production relation-classification call ended at 120.011s with `outcome=error`. The pipeline remained healthy and persisted the document, but the relation was skipped. Long-tail Codex latency needs a larger bounded timeout.

## Verification
- `npm run build`
- config tests 5/5
- Swarm wiring test 1/1
- live service currently has `LLM_REQUEST_TIMEOUT_MS=180000` and health 200
