### PR TITLE
fix: harden Codex relay URL validation

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -36,6 +36,18 @@ describe("LLM environment configuration", () => {
     assert.equal(config.LLM_REQUEST_TIMEOUT_MS, 180000);
   });
 
+  it("treats a blank optional Codex URL as absent for Anthropic", () => {
+    baseEnvironment();
+    process.env.ANTHROPIC_API_KEY = "anthropic-key";
+    process.env.OPENAI_CODEX_BASE_URL = "   ";
+    delete process.env.LLM_PROVIDER;
+
+    const config = loadConfig();
+
+    assert.equal(config.LLM_PROVIDER, "anthropic");
+    assert.equal(config.OPENAI_CODEX_BASE_URL, undefined);
+  });
+
   it("accepts a private Codex relay without requiring Anthropic", () => {
     baseEnvironment();
     process.env.LLM_PROVIDER = "openai-codex";
@@ -53,6 +65,20 @@ describe("LLM environment configuration", () => {
     process.env.OPENAI_CODEX_RELAY_KEY = "x".repeat(48);
     const config = loadConfig();
     assert.equal(config.OPENAI_CODEX_BASE_URL, "http://codex-oauth-bridge:18646/v1");
+  });
+
+  it("accepts numeric loopback hosts but rejects DNS names beginning with 127", () => {
+    baseEnvironment();
+    process.env.LLM_PROVIDER = "openai-codex";
+    process.env.OPENAI_CODEX_RELAY_KEY = "x".repeat(48);
+    process.env.OPENAI_CODEX_BASE_URL = "http://127.0.0.2:8646/v1";
+    assert.equal(loadConfig().OPENAI_CODEX_BASE_URL, "http://127.0.0.2:8646/v1");
+
+    process.env.OPENAI_CODEX_BASE_URL = "http://[::1]:8646/v1";
+    assert.equal(loadConfig().OPENAI_CODEX_BASE_URL, "http://[::1]:8646/v1");
+
+    process.env.OPENAI_CODEX_BASE_URL = "http://127.evil.example:8646/v1";
+    assert.throws(() => loadConfig(), /internal bridge or a private\/loopback address/);
   });
 
   it("loads the relay bearer from a Docker secret file", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ function isPrivateRelayUrl(value: string): boolean {
       return false;
     }
     const host = url.hostname.toLowerCase();
-    if (host === "localhost" || host === "::1" || host.startsWith("127.")) {
+    if (host === "localhost" || host === "[::1]") {
       return true;
     }
     if (host === "codex-oauth-bridge") {
@@ -20,6 +20,7 @@ function isPrivateRelayUrl(value: string): boolean {
     }
     const [first, second] = octets as [number, number, number, number];
     return first === 10
+      || first === 127
       || (first === 172 && second >= 16 && second <= 31)
       || (first === 192 && second === 168)
       || (first === 100 && second >= 64 && second <= 127);
@@ -119,7 +120,7 @@ export function loadConfig(): AppConfig {
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
     ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL,
     OPENAI_CODEX_MODEL: process.env.OPENAI_CODEX_MODEL,
-    OPENAI_CODEX_BASE_URL: process.env.OPENAI_CODEX_BASE_URL,
+    OPENAI_CODEX_BASE_URL: process.env.OPENAI_CODEX_BASE_URL?.trim() || undefined,
     OPENAI_CODEX_RELAY_KEY: provider === "openai-codex"
       ? resolveCodexRelayKey()
       : process.env.OPENAI_CODEX_RELAY_KEY?.trim() || undefined,


### PR DESCRIPTION
## Summary
- Normalize blank optional Codex relay URLs to absent so the documented Anthropic default remains valid.
- Accept `127.0.0.0/8` only through numeric IPv4 parsing, rejecting public DNS names such as `127.evil.example` before the bearer can be used.
- Correctly recognize Node's `[::1]` loopback hostname form and add focused regressions.

Follow-up to #40 and Codex review comments:
- https://github.com/ablott976/supermemento/pull/40#discussion_r3577223709
- https://github.com/ablott976/supermemento/pull/40#discussion_r3577223715

## Checks
- `node --import tsx --test src/config.test.ts` — 7 passed.
- `npm run build` — passed.
- `git diff --check` — passed.
- Native Codex audit: `gpt-5.6-terra`, read-only, final diff approved with no blockers.
- Claude final review: OAuth route, `claude-fable-5`, approved; API credits were not used.

## Security
The relay bearer and destination are the protected assets. Configuration validation fails closed for malformed/public hosts before the outbound client can use the bearer. No credentials, deployment configuration, or production data were changed.

`npm audit --omit=dev` still reports pre-existing transitive advisories outside this dependency-neutral diff; package files were not changed.
