### PR TITLE
fix: require decimal IPv4 relay labels

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -79,6 +79,12 @@ describe("LLM environment configuration", () => {
 
     process.env.OPENAI_CODEX_BASE_URL = "http://127.evil.example:8646/v1";
     assert.throws(() => loadConfig(), /internal bridge or a private\/loopback address/);
+
+    process.env.OPENAI_CODEX_BASE_URL = "http://127.0.0.1e2:8646/v1";
+    assert.throws(() => loadConfig(), /internal bridge or a private\/loopback address/);
+
+    process.env.OPENAI_CODEX_BASE_URL = "http://010.0.0.1:8646/v1";
+    assert.throws(() => loadConfig(), /internal bridge or a private\/loopback address/);
   });
 
   it("loads the relay bearer from a Docker secret file", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,8 +14,12 @@ function isPrivateRelayUrl(value: string): boolean {
     if (host === "codex-oauth-bridge") {
       return true;
     }
-    const octets = host.split(".").map(Number);
-    if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    const labels = host.split(".");
+    if (labels.length !== 4 || labels.some((part) => !/^\d{1,3}$/.test(part))) {
+      return false;
+    }
+    const octets = labels.map(Number);
+    if (octets.some((part) => part > 255)) {
       return false;
     }
     const [first, second] = octets as [number, number, number, number];


### PR DESCRIPTION
## Summary
- Require four decimal-only IPv4 labels before numeric private-range checks.
- Reject exponent/coercible DNS labels such as `127.0.0.1e2` before the relay bearer can reach an outbound client.
- Cover WHATWG normalization of leading-zero host input as a fail-closed boundary case.

Follow-up to #43 and Codex review comment: https://github.com/ablott976/supermemento/pull/43#discussion_r3577863139

## Checks
- `node --import tsx --test src/config.test.ts` — 7 passed.
- `npm run build` — passed.
- `git diff --check` — passed.
- Native Codex audit: `gpt-5.6-terra`, read-only, approved with no blockers.
- Claude final review: OAuth route, `claude-fable-5`, approved; API credits were not used. Its leading-zero note was verified against Node WHATWG normalization and pinned with a regression.

## Security
The relay bearer and destination remain the protected assets. Host validation now rejects non-decimal DNS labels before private IPv4 range acceptance. No credentials or deployment configuration were changed.
