### PR TITLE
Retry transient Codex streams once

### DIFF
--- a/docs/OPENAI_CODEX_OAUTH.md
+++ b/docs/OPENAI_CODEX_OAUTH.md
@@ -66,6 +66,7 @@ The relay URL must target loopback, the exact internal sidecar alias, RFC1918 or
 ## Failure and rollback
 
 - Missing/expired OAuth or an unreachable relay produces a provider error. Ingestion remains fail-closed and the historical coordinator pauses.
+- The application retries a complete Codex request once for transient transport/stream failures, HTTP 408/409/425/429/5xx, or an incomplete stream. Any partial output from the first attempt is discarded; deterministic 4xx and output-limit failures are not retried.
 - The relay retries once only after an upstream `401`, forcing OAuth refresh before the retry.
 - Rollback consists of setting `LLM_PROVIDER=anthropic`, restoring the prior image/config and stopping the relay if no other client uses it.
 - Do not automatically switch providers inside a single ingestion attempt; a provider change is an explicit operational action.

--- a/src/services/llm/text-generation-client.test.ts
+++ b/src/services/llm/text-generation-client.test.ts
@@ -98,6 +98,89 @@ describe("text generation providers", () => {
     assert.equal("tools" in (captured ?? {}), false);
   });
 
+  it("retries one transient stream failure and discards partial output", async () => {
+    let calls = 0;
+    const logLines: string[] = [];
+    const originalInfo = console.info;
+    console.info = (message?: unknown) => logLines.push(String(message));
+    try {
+      const client = new OpenAiCodexTextGenerationClient(
+        config({
+          LLM_PROVIDER: "openai-codex",
+          OPENAI_CODEX_BASE_URL: "http://100.104.0.187:8646/v1",
+          OPENAI_CODEX_RELAY_KEY: "relay-key"
+        }),
+        {
+          responses: {
+            create: async () => {
+              calls += 1;
+              if (calls === 1) {
+                return {
+                  async *[Symbol.asyncIterator]() {
+                    yield { type: "response.output_text.delta", delta: "discard-me" };
+                    throw new Error("sensitive transport timeout");
+                  }
+                };
+              }
+              return {
+                async *[Symbol.asyncIterator]() {
+                  yield { type: "response.output_text.delta", delta: '{"ok":true}' };
+                  yield { type: "response.completed" };
+                }
+              };
+            }
+          }
+        },
+        0
+      );
+
+      const result = await client.complete({
+        operation: "memory-extraction",
+        system: "s",
+        user: "u",
+        maxTokens: 64
+      });
+
+      assert.equal(result, '{"ok":true}');
+      assert.equal(calls, 2);
+    } finally {
+      console.info = originalInfo;
+    }
+    assert.equal(logLines.length, 1);
+    assert.match(logLines[0], /retry=1 reason=transient/);
+    assert.doesNotMatch(logLines[0], /sensitive|discard-me/);
+  });
+
+  it("stops after one transient retry is exhausted", async () => {
+    let calls = 0;
+    const client = new OpenAiCodexTextGenerationClient(
+      config({
+        LLM_PROVIDER: "openai-codex",
+        OPENAI_CODEX_BASE_URL: "http://100.104.0.187:8646/v1",
+        OPENAI_CODEX_RELAY_KEY: "relay-key"
+      }),
+      {
+        responses: {
+          create: async () => {
+            calls += 1;
+            return {
+              async *[Symbol.asyncIterator]() {
+                throw new Error("connection lost");
+              }
+            };
+          }
+        }
+      },
+      0
+    );
+
+    await assert.rejects(
+      client.complete({ operation: "extract", system: "s", user: "u", maxTokens: 64 }),
+      /openai-codex stream failed/
+    );
+    assert.equal(calls, 2);
+  });
+
   it("fails closed when the Codex stream has no text", async () => {
     const client = new OpenAiCodexTextGenerationClient(
       config({
@@ -177,6 +260,7 @@ describe("text generation providers", () => {
   });
 
   it("does not leak upstream response bodies in errors", async () => {
+    let calls = 0;
     const upstream = Object.assign(new Error("secret provider body"), { status: 401 });
     const client = new OpenAiCodexTextGenerationClient(
       config({
@@ -185,7 +269,7 @@ describe("text generation providers", () => {
         OPENAI_CODEX_RELAY_KEY: "relay-key"
       }),
       {
-        responses: { create: async () => { throw upstream; } }
+        responses: { create: async () => { calls += 1; throw upstream; } }
       }
     );
 
@@ -198,6 +282,37 @@ describe("text generation providers", () => {
         return true;
       }
     );
+    assert.equal(calls, 1);
+  });
+
+  it("does not retry deterministic output-limit failures", async () => {
+    let calls = 0;
+    const client = new OpenAiCodexTextGenerationClient(
+      config({
+        LLM_PROVIDER: "openai-codex",
+        OPENAI_CODEX_BASE_URL: "http://100.104.0.187:8646/v1",
+        OPENAI_CODEX_RELAY_KEY: "relay-key"
+      }),
+      {
+        responses: {
+          create: async () => {
+            calls += 1;
+            return {
+              async *[Symbol.asyncIterator]() {
+                yield { type: "response.output_text.delta", delta: "x".repeat(1025) };
+              }
+            };
+          }
+        }
+      },
+      0
+    );
+
+    await assert.rejects(
+      client.complete({ operation: "extract", system: "s", user: "u", maxTokens: 1 }),
+      /exceeded the configured output limit/
+    );
+    assert.equal(calls, 1);
   });
 
   it("requires relay configuration when Codex is selected", () => {

--- a/src/services/llm/text-generation-client.ts
+++ b/src/services/llm/text-generation-client.ts
@@ -29,6 +29,9 @@ type OpenAiResponsesLike = {
   };
 };
 
+const CODEX_MAX_ATTEMPTS = 2;
+const CODEX_RETRY_DELAY_MS = 1_000;
+
 function statusFromError(error: unknown): number | undefined {
   const status = (error as { status?: unknown } | null)?.status;
   return typeof status === "number" ? status : undefined;
@@ -43,6 +46,29 @@ function providerError(provider: string, phase: string, error: unknown): Error {
     Object.assign(wrapped, { status });
   }
   return wrapped;
+}
+
+function isRetryableCodexError(error: unknown): boolean {
+  const status = statusFromError(error);
+  if (status !== undefined) {
+    return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
+  }
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if (
+    error.message === "Codex response exceeded the configured output limit" ||
+    error.message.includes("returned no text")
+  ) {
+    return false;
+  }
+  return (
+    error.message.startsWith("openai-codex request failed") ||
+    error.message.startsWith("openai-codex stream failed") ||
+    error.message === "Codex response was incomplete" ||
+    error.message === "Codex response failed" ||
+    error.message === "Codex response ended without completion"
+  );
 }
 
 function requireNonEmpty(value: string | undefined, name: string): string {
@@ -127,7 +153,11 @@ export class OpenAiCodexTextGenerationClient implements TextGenerationClient {
   private readonly reasoningEffort: AppConfig["LLM_REASONING_EFFORT"];
   private readonly client: OpenAiResponsesLike;
 
-  public constructor(config: AppConfig, client?: OpenAiResponsesLike) {
+  public constructor(
+    config: AppConfig,
+    client?: OpenAiResponsesLike,
+    private readonly retryDelayMs = CODEX_RETRY_DELAY_MS
+  ) {
     const baseURL = requireNonEmpty(config.OPENAI_CODEX_BASE_URL, "OPENAI_CODEX_BASE_URL");
     const apiKey = requireNonEmpty(config.OPENAI_CODEX_RELAY_KEY, "OPENAI_CODEX_RELAY_KEY");
     this.model = config.OPENAI_CODEX_MODEL;
@@ -141,6 +171,27 @@ export class OpenAiCodexTextGenerationClient implements TextGenerationClient {
   }
 
   public async complete(request: TextGenerationRequest): Promise<string> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= CODEX_MAX_ATTEMPTS; attempt += 1) {
+      try {
+        return await this.completeOnce(request);
+      } catch (error) {
+        lastError = error;
+        if (attempt === CODEX_MAX_ATTEMPTS || !isRetryableCodexError(error)) {
+          throw error;
+        }
+        console.info(
+          `[llm] provider=${this.provider} model=${this.model} operation=${request.operation} retry=${attempt} reason=transient`
+        );
+        if (this.retryDelayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, this.retryDelayMs));
+        }
+      }
+    }
+    throw lastError;
+  }
+
+  private async completeOnce(request: TextGenerationRequest): Promise<string> {
     const maxCharacters = Math.max(1024, request.maxTokens * 8);
     let stream: AsyncIterable<Record<string, unknown>>;
     try {


### PR DESCRIPTION
## Summary
- retry one complete Codex Responses request after transient request/stream failures
- discard all partial output from the failed attempt
- keep SDK retries disabled so total attempts remain exactly two
- do not retry deterministic 4xx, empty-output or output-limit failures

## Root cause
Email 1296 reached the 180-second application timeout during `memory-extraction`. The OpenAI SDK was deliberately configured with `maxRetries: 0`, while the coordinator's second pass only re-read the already-failed document instead of re-running extraction.

## Verification
- `npm run build` — PASS
- text generation client tests — 11/11 PASS
- config and LLM consumer tests — 26/26 PASS
- diff check and secret scan — PASS
- focused `openai-codex/gpt-5.6-terra` audit — APPROVED, no blockers
- document 1296 reprocessed with the same UUID — done, 1 chunk, 7 memories
