### PR TITLE
fix: default crawled URL listing to canary container

### DIFF
--- a/chatgpt_gateway/server.py
+++ b/chatgpt_gateway/server.py
@@ -103,6 +103,9 @@ def build_transforms() -> list[Transform]:
         "list_documents": ToolTransformConfig(
             arguments={"containerTag": ArgTransformConfig(default="zkteco-pmm")}
         ),
+        "list_crawled_urls": ToolTransformConfig(
+            arguments={"containerTag": ArgTransformConfig(default="zkteco-pmm")}
+        ),
         "get_user_profile": ToolTransformConfig(
             arguments={"regenerate": ArgTransformConfig(default=False, hide=True)}
         ),

--- a/tests/test_chatgpt_gateway.py
+++ b/tests/test_chatgpt_gateway.py
@@ -134,10 +134,20 @@ def _backend() -> FastMCP:
         return {"containerTag": containerTag, "limit": limit}
 
     @backend.tool
+    async def list_crawled_urls(containerTag: str | None = None) -> dict:
+        return {"containerTag": containerTag}
+
+    @backend.tool
     async def delete_memory(memoryId: str) -> dict:
         return {"deleted": memoryId}
 
-    defined = {"semantic_search", "get_user_profile", "list_memories", "list_documents"}
+    defined = {
+        "semantic_search",
+        "get_user_profile",
+        "list_memories",
+        "list_documents",
+        "list_crawled_urls",
+    }
     for name in ALLOWED_TOOLS - defined:
 
         async def placeholder(value: str = "") -> dict:
@@ -175,6 +185,8 @@ def test_tool_surface_is_allowlisted_annotated_and_uses_safe_defaults() -> None:
                 "rewriteQuery": True,
                 "limit": 5,
             }
+            crawled_urls = await client.call_tool("list_crawled_urls", {})
+            assert crawled_urls.data == {"containerTag": "zkteco-pmm"}
             try:
                 await client.call_tool("delete_memory", {"memoryId": "blocked"})
             except Exception as exc:


### PR DESCRIPTION
## Summary
- default `list_crawled_urls` to the `zkteco-pmm` canary container when ChatGPT calls it without arguments
- add a gateway regression that exercises the empty-call path

## Checks
- `python -m pytest tests/test_chatgpt_gateway.py -q` (6 passed, Python 3.12 with locked gateway dependencies)
- `npm ci && npm run build`
- `git diff --check`
- focused Codex gpt-5.6-terra audit: APPROVED
- Claude OAuth claude-fable-5 final review: APPROVED