### PR TITLE
fix: harden OAuth readiness and client eviction

### DIFF
--- a/chatgpt_gateway/owner_oauth.py
+++ b/chatgpt_gateway/owner_oauth.py
@@ -1013,19 +1013,35 @@ class GatewayOAuthManager:
     def _reserve_client_slot(self) -> None:
         if len(self._clients) < self.max_clients:
             return
+        now = time.time()
+        active_client_ids = {
+            record.client_id
+            for store in (
+                self._pending_authorizations,
+                self._authorization_codes,
+                self._access_tokens,
+                self._refresh_tokens,
+            )
+            for record in store.values()
+            if record.expires_at >= now
+        }
         removable = sorted(
             (
                 client
                 for client in self._clients.values()
-                if client.authorized_at is None
+                if client.client_id not in active_client_ids
             ),
-            key=lambda client: client.issued_at,
+            key=lambda client: (
+                client.authorized_at is not None,
+                client.authorized_at or client.issued_at,
+                client.issued_at,
+            ),
         )
         needed = len(self._clients) - self.max_clients + 1
         if len(removable) < needed:
             raise OAuthFlowError(
                 "temporarily_unavailable",
-                "OAuth client registration capacity is reserved for already-authorized clients",
+                "OAuth client registration capacity is reserved for active clients",
                 status_code=503,
             )
         for client in removable[:needed]:

--- a/chatgpt_gateway/server.py
+++ b/chatgpt_gateway/server.py
@@ -248,8 +248,11 @@ def _consent_page(pending: Any, *, error: str | None = None) -> HTMLResponse:
 
 def _store_is_writable(store_path: str) -> bool:
     path = Path(store_path)
-    target = path if path.exists() else path.parent
-    return target.exists() and os.access(target, os.W_OK)
+    directory = path.parent
+    return (
+        directory.is_dir()
+        and os.access(directory, os.W_OK | os.X_OK)
+    )
 
 
 def create_gateway(

--- a/tests/test_chatgpt_gateway.py
+++ b/tests/test_chatgpt_gateway.py
@@ -268,6 +268,41 @@ def test_directory_fsync_failure_poisoned_manager_fails_closed(
         _register_client(manager)
 
 
+def test_ready_checks_existing_store_parent(
+    monkeypatch, tmp_path: Path
+) -> None:
+    cfg = settings(tmp_path)
+    manager = build_oauth_manager(cfg)
+    _register_client(manager)
+    provider = build_auth_provider(cfg, manager)
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(200, json={"status": "ok"})
+        )
+    )
+    gateway = create_gateway(
+        cfg,
+        target=_backend(),
+        auth_provider=provider,
+        oauth_manager=manager,
+        http_client=http_client,
+    )
+    app = gateway.http_app(path="/mcp", transport="http", stateless_http=True)
+    checked: list[tuple[Path, int]] = []
+
+    def deny_access(path: os.PathLike[str], mode: int) -> bool:
+        checked.append((Path(path), mode))
+        return False
+
+    with TestClient(app) as client:
+        monkeypatch.setattr(os, "access", deny_access)
+        response = client.get("/ready")
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "unavailable"}
+    assert checked == [(tmp_path, os.W_OK | os.X_OK)]
+
+
 def test_authorized_client_capacity_is_bounded(tmp_path: Path) -> None:
     store_path = tmp_path / "bounded-oauth.json"
     manager = GatewayOAuthManager(
@@ -287,6 +322,52 @@ def test_authorized_client_capacity_is_bounded(tmp_path: Path) -> None:
         _register_client(manager)
     after = json.loads(store_path.read_text(encoding="utf-8"))["clients"]
     assert after == before
+
+
+def test_client_with_pending_authorization_is_not_evicted_at_capacity(
+    tmp_path: Path,
+) -> None:
+    manager = GatewayOAuthManager(
+        issuer_url="https://mcp.example.test",
+        resource_url="https://mcp.example.test/mcp",
+        consent_token_sha256=sha256_token(OWNER_TOKEN),
+        max_clients=1,
+        oauth_store_path=str(tmp_path / "bounded-oauth.json"),
+    )
+    client = _register_client(manager)
+    manager.start_authorization(
+        {
+            "response_type": "code",
+            "client_id": client["client_id"],
+            "redirect_uri": CHATGPT_REDIRECT,
+            "code_challenge": _pkce_challenge("p" * 64),
+            "code_challenge_method": "S256",
+        }
+    )
+
+    with pytest.raises(OAuthFlowError, match="capacity"):
+        _register_client(manager)
+
+
+def test_expired_authorized_client_is_evicted_at_capacity(tmp_path: Path) -> None:
+    store_path = tmp_path / "bounded-oauth.json"
+    manager = GatewayOAuthManager(
+        issuer_url="https://mcp.example.test",
+        resource_url="https://mcp.example.test/mcp",
+        legacy_token_sha256=None,
+        consent_token_sha256=sha256_token(OWNER_TOKEN),
+        access_token_ttl_seconds=-1,
+        refresh_token_ttl_seconds=-1,
+        max_clients=1,
+        oauth_store_path=str(store_path),
+    )
+    expired = _register_client(manager)
+    _issue_token(manager, expired["client_id"])
+
+    replacement = _register_client(manager)
+
+    clients = json.loads(store_path.read_text(encoding="utf-8"))["clients"]
+    assert list(clients) == [replacement["client_id"]]
 
 
 def _backend() -> FastMCP:


### PR DESCRIPTION
## Summary
- check the OAuth store directory (write + traverse) in readiness because persistence uses temp-file replacement there
- free inactive historical DCR clients at capacity while preserving every client with unexpired OAuth state
- cover unwritable store parents, active pending consent, active token protection, and expired-client replacement

Follow-up to #49 and its late review findings.

## Verification
- `/tmp/supermemento-t_fc011f90-venv/bin/python -m pytest -q tests/test_chatgpt_gateway.py` — 11 passed
- `npm run build` — passed
- `git diff --check` — passed
- focused Codex `gpt-5.6-terra` re-audit — APPROVED
- final Claude `claude-fable-5` OAuth review — APPROVED

## Security
No credentials, raw OAuth tokens, scopes, TTL defaults, redirect policy, deployment, or real data were changed. Capacity eviction remains fail-closed when every registered client has unexpired OAuth state.
