### PR TITLE
fix: initialize writable OAuth data directory

### DIFF
--- a/chatgpt_gateway/Dockerfile
+++ b/chatgpt_gateway/Dockerfile
@@ -11,6 +11,7 @@ RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements.l
     && rm -f /tmp/requirements.lock
 
 COPY --chown=65532:65532 . /app/chatgpt_gateway
+RUN install -d -o 65532 -g 65532 -m 0700 /data
 
 USER 65532:65532
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- create `/data` before dropping Docker privileges
- assign uid/gid 65532 and mode 0700 for OAuth state confidentiality
- preserve the non-root runtime user

## Verification
- built `chatgpt_gateway/Dockerfile`
- mounted a fresh empty named volume at `/data`
- verified uid/gid 65532, mode 0700, writable access, and an OAuth-store round trip
- focused read-only security reviews approved the one-line diff