### PR TITLE
Use JSON MCP responses behind EasyPanel

### DIFF
--- a/chatgpt_gateway/server.py
+++ b/chatgpt_gateway/server.py
@@ -249,10 +249,7 @@ def _consent_page(pending: Any, *, error: str | None = None) -> HTMLResponse:
 def _store_is_writable(store_path: str) -> bool:
     path = Path(store_path)
     directory = path.parent
-    return (
-        directory.is_dir()
-        and os.access(directory, os.W_OK | os.X_OK)
-    )
+    return directory.is_dir() and os.access(directory, os.W_OK | os.X_OK)
 
 
 def create_gateway(
@@ -450,6 +447,7 @@ def main() -> None:
         port=settings.port,
         path="/mcp",
         stateless_http=True,
+        json_response=True,
         show_banner=False,
         host_origin_protection=True,
         allowed_hosts=[


### PR DESCRIPTION
Configure the stateless Streamable HTTP gateway to return application/json responses so the EasyPanel-managed Traefik route does not depend on a manual SSE `flushInterval` override.

Verification: Ruff check passed, 11 focused tests passed, dedicated EasyPanel Docker build passed, image import confirmed `json_response=True`.