### PR TITLE
Accept current ChatGPT OAuth callback format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ LLM_REASONING_EFFORT=low
 PUBLIC_BASE_URL=https://n8n-supermemento-chatgpt.9kpuqs.easypanel.host
 UPSTREAM_MCP_URL=http://n8n_supermemento:80/mcp
 UPSTREAM_ALLOWED_HOSTS=n8n_supermemento,n8n-supermemento,supermemento
-ALLOWED_CLIENT_REDIRECT_URIS=https://chatgpt.com/connector_platform_oauth_redirect
+ALLOWED_CLIENT_REDIRECT_URIS=https://chatgpt.com/connector/oauth/{callback_id},https://chatgpt.com/connector_platform_oauth_redirect
 # Store only the SHA-256 digest. Keep the raw owner/setup token outside the container.
 MCP_GATEWAY_OWNER_TOKEN_SHA256_FILE=/run/secrets/supermemento_chatgpt_owner_token_sha256
 MCP_GATEWAY_OAUTH_STORE_PATH=/data/oauth-store.json

--- a/chatgpt_gateway/config.py
+++ b/chatgpt_gateway/config.py
@@ -6,10 +6,16 @@ from dataclasses import dataclass
 from ipaddress import ip_address
 import os
 from pathlib import Path
+import re
 from urllib.parse import urlparse
 
 
-_DEFAULT_REDIRECT = "https://chatgpt.com/connector_platform_oauth_redirect"
+CHATGPT_DYNAMIC_REDIRECT_PATTERN = "https://chatgpt.com/connector/oauth/{callback_id}"
+CHATGPT_LEGACY_REDIRECT = "https://chatgpt.com/connector_platform_oauth_redirect"
+_DEFAULT_REDIRECTS = ",".join(
+    (CHATGPT_DYNAMIC_REDIRECT_PATTERN, CHATGPT_LEGACY_REDIRECT)
+)
+_CHATGPT_CALLBACK_ID = re.compile(r"[A-Za-z0-9_-]{1,256}")
 _DEFAULT_INTERNAL_HOSTS = frozenset(
     {"n8n_supermemento", "n8n-supermemento", "supermemento", "localhost"}
 )
@@ -94,6 +100,32 @@ def _validated_store_path(value: str) -> str:
     return str(path)
 
 
+def client_redirect_uri_allowed(uri: str, allowed_redirects: tuple[str, ...]) -> bool:
+    """Match exact redirects or ChatGPT's tightly scoped dynamic callback."""
+    if uri in allowed_redirects and uri != CHATGPT_DYNAMIC_REDIRECT_PATTERN:
+        return True
+    if CHATGPT_DYNAMIC_REDIRECT_PATTERN not in allowed_redirects:
+        return False
+    if "?" in uri or "#" in uri:
+        return False
+
+    parsed = urlparse(uri)
+    callback_prefix = "/connector/oauth/"
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc != "chatgpt.com"
+        or parsed.username
+        or parsed.password
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+        or not parsed.path.startswith(callback_prefix)
+    ):
+        return False
+    callback_id = parsed.path.removeprefix(callback_prefix)
+    return _CHATGPT_CALLBACK_ID.fullmatch(callback_id) is not None
+
+
 @dataclass(frozen=True, repr=False)
 class GatewaySettings:
     """Validated settings. Credential hashes are intentionally excluded from repr."""
@@ -134,10 +166,19 @@ class GatewaySettings:
         oauth_store_path = _validated_store_path(
             os.getenv("MCP_GATEWAY_OAUTH_STORE_PATH", "/data/oauth-store.json").strip()
         )
-        redirects = _csv("ALLOWED_CLIENT_REDIRECT_URIS", default=_DEFAULT_REDIRECT)
+        redirects = _csv("ALLOWED_CLIENT_REDIRECT_URIS", default=_DEFAULT_REDIRECTS)
         for redirect in redirects:
+            if redirect == CHATGPT_DYNAMIC_REDIRECT_PATTERN:
+                continue
             parsed = urlparse(redirect)
-            if parsed.scheme != "https" or not parsed.hostname or parsed.fragment:
+            if (
+                parsed.scheme != "https"
+                or not parsed.hostname
+                or parsed.username
+                or parsed.password
+                or parsed.query
+                or parsed.fragment
+            ):
                 raise ValueError(
                     "ALLOWED_CLIENT_REDIRECT_URIS must contain absolute HTTPS URLs"
                 )

--- a/chatgpt_gateway/server.py
+++ b/chatgpt_gateway/server.py
@@ -23,7 +23,7 @@ from pydantic import AnyHttpUrl
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
-from .config import GatewaySettings
+from .config import GatewaySettings, client_redirect_uri_allowed
 from .owner_oauth import (
     PUBLIC_SCOPES,
     GatewayOAuthManager,
@@ -328,7 +328,9 @@ def create_gateway(
                 )
             if any(
                 not isinstance(uri, str)
-                or uri not in settings.allowed_client_redirect_uris
+                or not client_redirect_uri_allowed(
+                    uri, settings.allowed_client_redirect_uris
+                )
                 for uri in redirect_uris
             ):
                 raise OAuthFlowError(

--- a/docs/CHATGPT_MCP_GATEWAY.md
+++ b/docs/CHATGPT_MCP_GATEWAY.md
@@ -53,7 +53,7 @@ PY
 - `ingest_url`, `ingest_document` y `crawl_*` quedan fuera hasta corregir la validación SSRF común.
 - `setup_schema`, mantenimiento, delete, forget y update no se publican.
 - Rate limit global, respuestas limitadas y errores internos ocultos.
-- Imagen non-root, dependencias fijadas con hashes y root filesystem read-only en producción.
+- Imagen non-root, dependencias fijadas con hashes, Tini y `Cap Drop=ALL` en EasyPanel.
 
 ## Configuración
 
@@ -61,13 +61,15 @@ PY
 PUBLIC_BASE_URL=https://n8n-supermemento-chatgpt.9kpuqs.easypanel.host
 UPSTREAM_MCP_URL=http://n8n_supermemento:80/mcp
 UPSTREAM_ALLOWED_HOSTS=n8n_supermemento
-ALLOWED_CLIENT_REDIRECT_URIS=https://chatgpt.com/connector_platform_oauth_redirect
+ALLOWED_CLIENT_REDIRECT_URIS=https://chatgpt.com/connector/oauth/{callback_id},https://chatgpt.com/connector_platform_oauth_redirect
 MCP_GATEWAY_OWNER_TOKEN_SHA256_FILE=/run/secrets/supermemento_chatgpt_owner_token_sha256
 MCP_GATEWAY_OAUTH_STORE_PATH=/data/oauth-store.json
 PORT=8080
 ```
 
 El upstream solo acepta HTTP interno con hostname allowlisted. El gateway no necesita claves de Neo4j, OpenAI, Anthropic ni `supermemento-api`.
+
+Para apps nuevas, OpenAI asigna un callback dinámico `https://chatgpt.com/connector/oauth/{callback_id}`. El gateway solo acepta HTTPS, host exacto `chatgpt.com`, un único `callback_id` alfanumérico/base64url y ninguna credencial, query, fragmento, puerto o ruta adicional. El callback legado se mantiene como coincidencia exacta para apps ya publicadas.
 
 ## Persistencia
 

--- a/tests/test_chatgpt_gateway.py
+++ b/tests/test_chatgpt_gateway.py
@@ -15,7 +15,11 @@ import httpx
 import pytest
 from starlette.testclient import TestClient
 
-from chatgpt_gateway.config import GatewaySettings
+from chatgpt_gateway.config import (
+    CHATGPT_DYNAMIC_REDIRECT_PATTERN,
+    GatewaySettings,
+    client_redirect_uri_allowed,
+)
 from chatgpt_gateway.owner_oauth import (
     GatewayOAuthManager,
     OAuthFlowError,
@@ -33,6 +37,7 @@ from chatgpt_gateway.server import (
 
 OWNER_TOKEN = "smo_" + "owner-token-for-focused-tests" * 2
 CHATGPT_REDIRECT = "https://chatgpt.com/connector_platform_oauth_redirect"
+CHATGPT_DYNAMIC_REDIRECT = "https://chatgpt.com/connector/oauth/cb_test-123"
 
 
 def settings(tmp_path: Path) -> GatewaySettings:
@@ -43,7 +48,10 @@ def settings(tmp_path: Path) -> GatewaySettings:
         upstream_health_url="http://supermemento:80/health",
         owner_token_sha256=sha256_token(OWNER_TOKEN),
         oauth_store_path=str(tmp_path / "oauth-store.json"),
-        allowed_client_redirect_uris=(CHATGPT_REDIRECT,),
+        allowed_client_redirect_uris=(
+            CHATGPT_DYNAMIC_REDIRECT_PATTERN,
+            CHATGPT_REDIRECT,
+        ),
         port=8080,
     )
 
@@ -51,6 +59,31 @@ def settings(tmp_path: Path) -> GatewaySettings:
 def _pkce_challenge(verifier: str) -> str:
     digest = hashlib.sha256(verifier.encode("ascii")).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+@pytest.mark.parametrize(
+    ("redirect_uri", "allowed"),
+    [
+        (CHATGPT_DYNAMIC_REDIRECT, True),
+        (CHATGPT_REDIRECT, True),
+        ("https://chatgpt.com/connector/oauth/abc_DEF-123", True),
+        (CHATGPT_DYNAMIC_REDIRECT_PATTERN, False),
+        ("https://evil.example/connector/oauth/abc", False),
+        ("https://chatgpt.com/connector/oauth/", False),
+        ("https://chatgpt.com/connector/oauth/a/b", False),
+        ("https://chatgpt.com/connector/oauth/abc?next=evil", False),
+        ("https://chatgpt.com/connector/oauth/abc?", False),
+        ("https://chatgpt.com/connector/oauth/abc#fragment", False),
+        ("https://chatgpt.com/connector/oauth/abc#", False),
+        ("https://user@chatgpt.com/connector/oauth/abc", False),
+        ("https://chatgpt.com:443/connector/oauth/abc", False),
+        ("https://chatgpt.com/connector/oauth/abc%2Fdef", False),
+        ("http://chatgpt.com/connector/oauth/abc", False),
+    ],
+)
+def test_chatgpt_dynamic_redirect_is_strict(redirect_uri: str, allowed: bool) -> None:
+    configured = (CHATGPT_DYNAMIC_REDIRECT_PATTERN, CHATGPT_REDIRECT)
+    assert client_redirect_uri_allowed(redirect_uri, configured) is allowed
 
 
 def _register_client(manager) -> dict:
@@ -268,9 +301,7 @@ def test_directory_fsync_failure_poisoned_manager_fails_closed(
         _register_client(manager)
 
 
-def test_ready_checks_existing_store_parent(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_ready_checks_existing_store_parent(monkeypatch, tmp_path: Path) -> None:
     cfg = settings(tmp_path)
     manager = build_oauth_manager(cfg)
     _register_client(manager)
@@ -527,6 +558,20 @@ def test_http_oauth_dcr_redirects_and_authenticated_mcp(tmp_path: Path) -> None:
         }
         allowed_registration = client.post("/register", json=registration)
         assert allowed_registration.status_code == 201
+        dynamic_registration = client.post(
+            "/register",
+            json={**registration, "redirect_uris": [CHATGPT_DYNAMIC_REDIRECT]},
+        )
+        assert dynamic_registration.status_code == 201
+        literal_template_registration = client.post(
+            "/register",
+            json={
+                **registration,
+                "redirect_uris": [CHATGPT_DYNAMIC_REDIRECT_PATTERN],
+            },
+        )
+        assert literal_template_registration.status_code == 400
+        assert literal_template_registration.json()["error"] == "invalid_redirect_uri"
         rejected_registration = client.post(
             "/register",
             json={**registration, "redirect_uris": ["https://evil.example/callback"]},


### PR DESCRIPTION
Fix Dynamic Client Registration for new ChatGPT apps, which use `https://chatgpt.com/connector/oauth/{callback_id}` rather than only the legacy callback.

The matcher is fail-closed: HTTPS, exact host, one base64url callback ID, and no credentials, port, query, fragment, encoding or extra path. Literal template registration is rejected.

Verification: Ruff passed; 26 focused tests passed; EasyPanel Docker build passed; focused `openai-codex/gpt-5.6-terra` re-audit approved.