### PR TITLE
Handle ChatGPT callbacks without env patterns

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ LLM_REASONING_EFFORT=low
 PUBLIC_BASE_URL=https://n8n-supermemento-chatgpt.9kpuqs.easypanel.host
 UPSTREAM_MCP_URL=http://n8n_supermemento:80/mcp
 UPSTREAM_ALLOWED_HOSTS=n8n_supermemento,n8n-supermemento,supermemento
-ALLOWED_CLIENT_REDIRECT_URIS=https://chatgpt.com/connector/oauth/{callback_id},https://chatgpt.com/connector_platform_oauth_redirect
+ALLOWED_CLIENT_REDIRECT_URIS=https://chatgpt.com/connector_platform_oauth_redirect
 # Store only the SHA-256 digest. Keep the raw owner/setup token outside the container.
 MCP_GATEWAY_OWNER_TOKEN_SHA256_FILE=/run/secrets/supermemento_chatgpt_owner_token_sha256
 MCP_GATEWAY_OAUTH_STORE_PATH=/data/oauth-store.json

--- a/chatgpt_gateway/config.py
+++ b/chatgpt_gateway/config.py
@@ -9,12 +9,9 @@ from pathlib import Path
 import re
 from urllib.parse import urlparse
 
-
 CHATGPT_DYNAMIC_REDIRECT_PATTERN = "https://chatgpt.com/connector/oauth/{callback_id}"
 CHATGPT_LEGACY_REDIRECT = "https://chatgpt.com/connector_platform_oauth_redirect"
-_DEFAULT_REDIRECTS = ",".join(
-    (CHATGPT_DYNAMIC_REDIRECT_PATTERN, CHATGPT_LEGACY_REDIRECT)
-)
+_DEFAULT_REDIRECT = CHATGPT_LEGACY_REDIRECT
 _CHATGPT_CALLBACK_ID = re.compile(r"[A-Za-z0-9_-]{1,256}")
 _DEFAULT_INTERNAL_HOSTS = frozenset(
     {"n8n_supermemento", "n8n-supermemento", "supermemento", "localhost"}
@@ -102,10 +99,8 @@ def _validated_store_path(value: str) -> str:
 
 def client_redirect_uri_allowed(uri: str, allowed_redirects: tuple[str, ...]) -> bool:
     """Match exact redirects or ChatGPT's tightly scoped dynamic callback."""
-    if uri in allowed_redirects and uri != CHATGPT_DYNAMIC_REDIRECT_PATTERN:
+    if uri in allowed_redirects:
         return True
-    if CHATGPT_DYNAMIC_REDIRECT_PATTERN not in allowed_redirects:
-        return False
     if "?" in uri or "#" in uri:
         return False
 
@@ -166,10 +161,8 @@ class GatewaySettings:
         oauth_store_path = _validated_store_path(
             os.getenv("MCP_GATEWAY_OAUTH_STORE_PATH", "/data/oauth-store.json").strip()
         )
-        redirects = _csv("ALLOWED_CLIENT_REDIRECT_URIS", default=_DEFAULT_REDIRECTS)
+        redirects = _csv("ALLOWED_CLIENT_REDIRECT_URIS", default=_DEFAULT_REDIRECT)
         for redirect in redirects:
-            if redirect == CHATGPT_DYNAMIC_REDIRECT_PATTERN:
-                continue
             parsed = urlparse(redirect)
             if (
                 parsed.scheme != "https"

--- a/docs/CHATGPT_MCP_GATEWAY.md
+++ b/docs/CHATGPT_MCP_GATEWAY.md
@@ -61,7 +61,7 @@ PY
 PUBLIC_BASE_URL=https://n8n-supermemento-chatgpt.9kpuqs.easypanel.host
 UPSTREAM_MCP_URL=http://n8n_supermemento:80/mcp
 UPSTREAM_ALLOWED_HOSTS=n8n_supermemento
-ALLOWED_CLIENT_REDIRECT_URIS=https://chatgpt.com/connector/oauth/{callback_id},https://chatgpt.com/connector_platform_oauth_redirect
+ALLOWED_CLIENT_REDIRECT_URIS=https://chatgpt.com/connector_platform_oauth_redirect
 MCP_GATEWAY_OWNER_TOKEN_SHA256_FILE=/run/secrets/supermemento_chatgpt_owner_token_sha256
 MCP_GATEWAY_OAUTH_STORE_PATH=/data/oauth-store.json
 PORT=8080
@@ -69,7 +69,7 @@ PORT=8080
 
 El upstream solo acepta HTTP interno con hostname allowlisted. El gateway no necesita claves de Neo4j, OpenAI, Anthropic ni `supermemento-api`.
 
-Para apps nuevas, OpenAI asigna un callback dinámico `https://chatgpt.com/connector/oauth/{callback_id}`. El gateway solo acepta HTTPS, host exacto `chatgpt.com`, un único `callback_id` alfanumérico/base64url y ninguna credencial, query, fragmento, puerto o ruta adicional. El callback legado se mantiene como coincidencia exacta para apps ya publicadas.
+Para apps nuevas, OpenAI asigna un callback dinámico `https://chatgpt.com/connector/oauth/{callback_id}`. El gateway reconoce internamente solo ese patrón oficial: HTTPS, host exacto `chatgpt.com`, un único `callback_id` alfanumérico/base64url y ninguna credencial, query, fragmento, puerto o ruta adicional. `ALLOWED_CLIENT_REDIRECT_URIS` queda reservado para callbacks exactos, incluido el legado de apps ya publicadas; no contiene patrones que EasyPanel pueda reinterpretar.
 
 ## Persistencia
 

--- a/tests/test_chatgpt_gateway.py
+++ b/tests/test_chatgpt_gateway.py
@@ -48,10 +48,7 @@ def settings(tmp_path: Path) -> GatewaySettings:
         upstream_health_url="http://supermemento:80/health",
         owner_token_sha256=sha256_token(OWNER_TOKEN),
         oauth_store_path=str(tmp_path / "oauth-store.json"),
-        allowed_client_redirect_uris=(
-            CHATGPT_DYNAMIC_REDIRECT_PATTERN,
-            CHATGPT_REDIRECT,
-        ),
+        allowed_client_redirect_uris=(CHATGPT_REDIRECT,),
         port=8080,
     )
 
@@ -82,7 +79,7 @@ def _pkce_challenge(verifier: str) -> str:
     ],
 )
 def test_chatgpt_dynamic_redirect_is_strict(redirect_uri: str, allowed: bool) -> None:
-    configured = (CHATGPT_DYNAMIC_REDIRECT_PATTERN, CHATGPT_REDIRECT)
+    configured = (CHATGPT_REDIRECT,)
     assert client_redirect_uri_allowed(redirect_uri, configured) is allowed
 
 


### PR DESCRIPTION
Follow-up to #54: recognize the tightly validated official ChatGPT dynamic callback inside the ChatGPT-specific gateway while keeping `ALLOWED_CLIENT_REDIRECT_URIS` for exact callbacks only. This avoids EasyPanel silently reverting pattern syntax in environment values.

Security behavior is unchanged: exact HTTPS host/path, one base64url callback ID, no credentials, port, query, fragment, encoding or extra path.

Verification: Ruff passed, 26 focused tests passed, EasyPanel Docker build passed. No third external audit per policy; #54 focused re-audit already approved the parser.