### PR TITLE
Allow trusted OAuth browser origins

### DIFF
--- a/chatgpt_gateway/server.py
+++ b/chatgpt_gateway/server.py
@@ -57,6 +57,21 @@ TOOL_POLICIES: dict[str, ToolPolicy] = {
 ALLOWED_TOOLS = frozenset(TOOL_POLICIES)
 
 
+def build_host_origin_options(settings: GatewaySettings) -> dict[str, object]:
+    """Return the exact public hosts and browser origins trusted in production."""
+    return {
+        "host_origin_protection": True,
+        "allowed_hosts": [
+            settings.public_hostname,
+            "localhost",
+            "127.0.0.1",
+            "supermemento-chatgpt",
+            "n8n-supermemento-chatgpt",
+        ],
+        "allowed_origins": [settings.public_base_url, "https://chatgpt.com"],
+    }
+
+
 class ChatGPTAnnotations(Transform):
     """Attach explicit MCP safety annotations to allowlisted tools."""
 
@@ -451,15 +466,8 @@ def main() -> None:
         stateless_http=True,
         json_response=True,
         show_banner=False,
-        host_origin_protection=True,
-        allowed_hosts=[
-            settings.public_hostname,
-            "localhost",
-            "127.0.0.1",
-            "supermemento-chatgpt",
-            "n8n-supermemento-chatgpt",
-        ],
         uvicorn_config={"access_log": False, "server_header": False},
+        **build_host_origin_options(settings),
     )
 
 

--- a/docs/CHATGPT_MCP_GATEWAY.md
+++ b/docs/CHATGPT_MCP_GATEWAY.md
@@ -53,6 +53,7 @@ PY
 - `ingest_url`, `ingest_document` y `crawl_*` quedan fuera hasta corregir la validación SSRF común.
 - `setup_schema`, mantenimiento, delete, forget y update no se publican.
 - Rate limit global, respuestas limitadas y errores internos ocultos.
+- Protección Host/Origin estricta: solo el dominio público del gateway y `https://chatgpt.com` pueden originar peticiones de navegador; cualquier otro origen se rechaza antes de OAuth.
 - Imagen non-root, dependencias fijadas con hashes, Tini y `Cap Drop=ALL` en EasyPanel.
 
 ## Configuración

--- a/tests/test_chatgpt_gateway.py
+++ b/tests/test_chatgpt_gateway.py
@@ -29,6 +29,7 @@ from chatgpt_gateway.owner_oauth import (
 from chatgpt_gateway.server import (
     ALLOWED_TOOLS,
     build_auth_provider,
+    build_host_origin_options,
     build_oauth_manager,
     build_transforms,
     create_gateway,
@@ -81,6 +82,54 @@ def _pkce_challenge(verifier: str) -> str:
 def test_chatgpt_dynamic_redirect_is_strict(redirect_uri: str, allowed: bool) -> None:
     configured = (CHATGPT_REDIRECT,)
     assert client_redirect_uri_allowed(redirect_uri, configured) is allowed
+
+
+def test_host_origin_guard_allows_only_gateway_and_chatgpt(tmp_path: Path) -> None:
+    cfg = settings(tmp_path)
+    manager = build_oauth_manager(cfg)
+    provider = build_auth_provider(cfg, manager)
+    gateway = create_gateway(
+        cfg,
+        target=_backend(),
+        auth_provider=provider,
+        oauth_manager=manager,
+    )
+    app = gateway.http_app(
+        path="/mcp",
+        transport="http",
+        stateless_http=True,
+        json_response=True,
+        **build_host_origin_options(cfg),
+    )
+    registration = {
+        "client_name": "ChatGPT origin test",
+        "redirect_uris": [CHATGPT_DYNAMIC_REDIRECT],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+        "scope": "supermemento:access",
+    }
+    with TestClient(app, base_url=cfg.public_base_url) as client:
+        same_origin = client.post(
+            "/register", headers={"Origin": cfg.public_base_url}, json=registration
+        )
+        assert same_origin.status_code == 201
+
+        chatgpt_origin = client.post(
+            "/register",
+            headers={"Origin": "https://chatgpt.com"},
+            json=registration,
+        )
+        assert chatgpt_origin.status_code == 201
+
+        for rejected_origin in ("https://evil.example", "null"):
+            rejected = client.post(
+                "/register",
+                headers={"Origin": rejected_origin},
+                json=registration,
+            )
+            assert rejected.status_code == 403
+            assert rejected.text == "Forbidden Origin"
 
 
 def _register_client(manager) -> dict:


### PR DESCRIPTION
Fix `403 Forbidden Origin` on the ChatGPT owner-consent form. FastMCP Host/Origin protection remains strict but now trusts exactly the gateway public origin and `https://chatgpt.com`. Other origins, including `null`, remain blocked.

Verification: Ruff passed; 27 focused gateway tests passed; dedicated EasyPanel Docker build passed. Production test plan: same-origin and ChatGPT Origin pass OAuth routes, evil/null remain 403, then full OAuth PKCE and MCP canary.