### PR TITLE
Reject the literal ChatGPT redirect template

### DIFF
--- a/chatgpt_gateway/config.py
+++ b/chatgpt_gateway/config.py
@@ -99,6 +99,8 @@ def _validated_store_path(value: str) -> str:
 
 def client_redirect_uri_allowed(uri: str, allowed_redirects: tuple[str, ...]) -> bool:
     """Match exact redirects or ChatGPT's tightly scoped dynamic callback."""
+    if uri == CHATGPT_DYNAMIC_REDIRECT_PATTERN:
+        return False
     if uri in allowed_redirects:
         return True
     if "?" in uri or "#" in uri:

--- a/tests/test_chatgpt_gateway.py
+++ b/tests/test_chatgpt_gateway.py
@@ -84,6 +84,11 @@ def test_chatgpt_dynamic_redirect_is_strict(redirect_uri: str, allowed: bool) ->
     assert client_redirect_uri_allowed(redirect_uri, configured) is allowed
 
 
+def test_chatgpt_dynamic_redirect_template_is_rejected_even_if_configured() -> None:
+    configured = (CHATGPT_DYNAMIC_REDIRECT_PATTERN,)
+    assert not client_redirect_uri_allowed(CHATGPT_DYNAMIC_REDIRECT_PATTERN, configured)
+
+
 def test_host_origin_guard_allows_only_gateway_and_chatgpt(tmp_path: Path) -> None:
     cfg = settings(tmp_path)
     manager = build_oauth_manager(cfg)


### PR DESCRIPTION
## Summary
- reject the non-executable `{callback_id}` redirect template before exact allowlist matching
- cover upgraded deployments that still configure the legacy template

## Checks
- `uv run --with-requirements chatgpt_gateway/requirements.lock --with pytest python -m pytest tests/test_chatgpt_gateway.py -k "dynamic_redirect" -q` (16 passed)