### PR TITLE
fix: reject malformed OAuth redirect URIs

### DIFF
--- a/chatgpt_gateway/config.py
+++ b/chatgpt_gateway/config.py
@@ -101,12 +101,17 @@ def client_redirect_uri_allowed(uri: str, allowed_redirects: tuple[str, ...]) ->
     """Match exact redirects or ChatGPT's tightly scoped dynamic callback."""
     if uri == CHATGPT_DYNAMIC_REDIRECT_PATTERN:
         return False
+    if any(ord(char) <= 0x20 or ord(char) == 0x7F for char in uri):
+        return False
     if uri in allowed_redirects:
         return True
     if "?" in uri or "#" in uri:
         return False
 
-    parsed = urlparse(uri)
+    try:
+        parsed = urlparse(uri)
+    except ValueError:
+        return False
     callback_prefix = "/connector/oauth/"
     if (
         parsed.scheme != "https"

--- a/tests/test_chatgpt_gateway.py
+++ b/tests/test_chatgpt_gateway.py
@@ -77,6 +77,10 @@ def _pkce_challenge(verifier: str) -> str:
         ("https://chatgpt.com:443/connector/oauth/abc", False),
         ("https://chatgpt.com/connector/oauth/abc%2Fdef", False),
         ("http://chatgpt.com/connector/oauth/abc", False),
+        (" https://chatgpt.com/connector/oauth/abc", False),
+        ("\x00https://chatgpt.com/connector/oauth/abc", False),
+        ("https://chatgpt.com/connector/oauth/abc\n", False),
+        ("https://[chatgpt.com/connector/oauth/abc", False),
     ],
 )
 def test_chatgpt_dynamic_redirect_is_strict(redirect_uri: str, allowed: bool) -> None:
@@ -629,6 +633,16 @@ def test_http_oauth_dcr_redirects_and_authenticated_mcp(tmp_path: Path) -> None:
         )
         assert rejected_registration.status_code == 400
         assert rejected_registration.json()["error"] == "invalid_redirect_uri"
+        for malformed_redirect in (
+            "https://[chatgpt.com/connector/oauth/abc",
+            f" {CHATGPT_DYNAMIC_REDIRECT}",
+        ):
+            malformed_registration = client.post(
+                "/register",
+                json={**registration, "redirect_uris": [malformed_redirect]},
+            )
+            assert malformed_registration.status_code == 400
+            assert malformed_registration.json()["error"] == "invalid_redirect_uri"
 
         access_token, _, _ = _issue_token(
             manager, allowed_registration.json()["client_id"]


### PR DESCRIPTION
Follow-up to #54 and review discussion r3621630380.

Summary:
- reject raw C0, spaces, and DEL before redirect matching
- turn malformed URL parse failures into `invalid_redirect_uri`
- cover helper and `/register` regressions

Checks:
- Python 3.12 focused pytest: 20 passed, 11 deselected
- `git diff --check`
- focused Codex and Claude OAuth security reviews: approved